### PR TITLE
mkEpicsPackages,epics-base: remove usage of passAsFile

### DIFF
--- a/pkgs/build-support/mk-epics-package.nix
+++ b/pkgs/build-support/mk-epics-package.nix
@@ -17,7 +17,6 @@
   nativeBuildInputs ? [],
   buildInputs ? [],
   makeFlags ? [],
-  passAsFile ? [],
   preBuild ? "",
   postInstall ? "",
   postFixup ? "",
@@ -81,17 +80,10 @@ in
       # directory and this variable is a source of conflicts between RELEASE files
       local_release = generateConf (local_release // {SUPPORT = null;});
 
-      passAsFile =
-        passAsFile
-        ++ [
-          "local_config_site"
-          "local_release"
-        ];
-
       preBuild =
         ''
-          cp -fv --no-preserve=mode "$local_config_sitePath" configure/CONFIG_SITE.local
-          cp -fv --no-preserve=mode "$local_releasePath" configure/RELEASE.local
+          echo "$local_config_site" > configure/CONFIG_SITE.local
+          echo "$local_release" > configure/RELEASE.local
 
           # set to empty if unset
           : "''${EPICS_COMPONENTS=}"

--- a/pkgs/epnix/epics-base/default.nix
+++ b/pkgs/epnix/epics-base/default.nix
@@ -92,14 +92,9 @@ in
           CMPLR_CLASS = "clang";
         });
 
-    passAsFile = [
-      "build_config_site"
-      "host_config_site"
-    ];
-
     preBuild = ''
-      cp -fv --no-preserve=mode "$build_config_sitePath" configure/os/CONFIG_SITE.${build_arch}.${build_arch}
-      cp -fv --no-preserve=mode "$host_config_sitePath" configure/os/CONFIG_SITE.${build_arch}.${host_arch}
+      echo "$build_config_site" > configure/os/CONFIG_SITE.${build_arch}.${build_arch}
+      echo "$host_config_site" > configure/os/CONFIG_SITE.${build_arch}.${host_arch}
 
       echo "=============================="
       echo "CONFIG_SITE.${build_arch}.${build_arch}"


### PR DESCRIPTION
causes issues with `nix develop`, see nix issue 7265