### PR TITLE
pkgs: make package sets extensible

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         overlays = [overlay inputs.bash-lib.overlay];
       };
     in {
-      packages = flake-utils.lib.flattenTree (pkgs.recurseIntoAttrs pkgs.epnix);
+      packages = flake-utils.lib.flattenTree pkgs.epnix;
 
       checks =
         {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,11 +1,15 @@
-epnixLib: final: prev:
-with prev;
-  recurseIntoAttrs rec {
+epnixLib: final: prev: let
+  inherit (final) callPackage;
+  # From prev, else it somehow causes an infinite recursion
+  inherit (prev) recurseIntoAttrs;
+  recurseExtensible = f: recurseIntoAttrs (final.lib.makeExtensible f);
+in
+  recurseIntoAttrs {
     inherit epnixLib;
 
     mkEpicsPackage = callPackage ./build-support/mk-epics-package.nix {};
 
-    epnix = recurseIntoAttrs rec {
+    epnix = recurseExtensible (self: {
       # EPICS base
 
       epics-base7 = callPackage ./epnix/epics-base {
@@ -16,11 +20,11 @@ with prev;
         version = "3.15.9";
         hash = "sha256-QWScmCEaG0F6OW6LPCaFur4W57oRl822p7wpzbYhOuA=";
       };
-      epics-base = epics-base7;
+      epics-base = self.epics-base7;
 
       # EPICS support modules
 
-      support = recurseIntoAttrs {
+      support = recurseExtensible (_self: {
         asyn = callPackage ./epnix/support/asyn {};
         autosave = callPackage ./epnix/support/autosave {};
         calc = callPackage ./epnix/support/calc {};
@@ -31,7 +35,7 @@ with prev;
         snmp = callPackage ./epnix/support/snmp {};
         sscan = callPackage ./epnix/support/sscan {};
         StreamDevice = callPackage ./epnix/support/StreamDevice {};
-      };
+      });
 
       # EPICS related tools and extensions
 
@@ -61,5 +65,5 @@ with prev;
       # EPNix specific packages
       book = callPackage ./book {};
       manpages = callPackage ./manpages {};
-    };
+    });
   }


### PR DESCRIPTION
this enables easier overriding of packages, like this:

```nix
nixpkgs.overlays = [
  (final: prev: {
    epnix = prev.epnix.extend (final: prev: {
      epics-base7 = prev.epics-base7.overrideAttrs (oldAttrs: {
        patches = oldAttrs.patches ++ [ ./my.patch ];
      });
    });
  })
];
```

cc @stephane-cea since you might use this feature for overriding epics-base. The old method should still work.