### PR TITLE
Checks imports

### DIFF
--- a/templates/top/flake.nix
+++ b/templates/top/flake.nix
@@ -43,7 +43,7 @@
 
         # Add your integration tests:
         # ---
-        checks.files = [./checks/simple.nix];
+        checks.imports = [./checks/simple.nix];
 
         # Used when generating NixOS systemd services, for example for
         # deployment to production, or for the NixOS tests in checks/


### PR DESCRIPTION
this simplifies parametrized tests
this is now possible:

``` nix
checks.imports = [
  (import ./checks/common.nix "epics-base3")
  (import ./checks/common.nix "epics-base7")
];
```

cc @stephane-cea, since you needed this to test an support module for multiple epics-base versions.