### PR TITLE
Correction for documentation

### DIFF
--- a/doc/nixos/guides/_pre-requisites.md
+++ b/doc/nixos/guides/_pre-requisites.md
@@ -19,6 +19,7 @@ For example:
  {
    # ...
 +  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
++  inputs.epnix.url = "github:epics-extensions/EPNix";
 
    # ...
    outputs = {

--- a/doc/nixos/guides/phoebus-alarm.md
+++ b/doc/nixos/guides/phoebus-alarm.md
@@ -40,7 +40,7 @@ add this to your configuration:
   kafkaSock = "${ip}:${kafkaPort}";
 in {
   # The Phoebus Alarm server also automatically enables the Phoebus Alarm Logger
-  services.phoebus-alarm = {
+  services.phoebus-alarm-server = {
     enable = true;
     openFirewall = true;
     settings."org.phoebus.applications.alarm/server" = "${kafkaSock}";


### PR DESCRIPTION
Add epnix input in pre-requisites
Change name option in the documentation of phoebus alarm