### PR TITLE
add mrfioc2 and devlib2 support

### DIFF
--- a/lib/maintainers/maintainer-list.nix
+++ b/lib/maintainers/maintainer-list.nix
@@ -45,6 +45,10 @@ Please keep the list alphabetically sorted.
 See `<nixpkgs/maintainers/scripts/check-maintainer-github-handles.sh>` for an example on how to work with this data.
 */
 {
+  agaget = {
+    email = "alexis.gaget@cea.fr";
+    name = "Alexis Gaget";
+  };
   minijackson = {
     email = "remi.nicole@cea.fr";
     name = "Rémi Nicole";
@@ -61,9 +65,5 @@ See `<nixpkgs/maintainers/scripts/check-maintainer-github-handles.sh>` for an ex
   stephane = {
     email = "stephane.tzvetkov@cea.fr";
     name = "Stéphane Tzvetkov";
-  };
-  agaget = {
-    email = "alexis.gaget@cea.fr";
-    name = "Alexis Gaget";
   };
 }

--- a/lib/maintainers/maintainer-list.nix
+++ b/lib/maintainers/maintainer-list.nix
@@ -62,4 +62,8 @@ See `<nixpkgs/maintainers/scripts/check-maintainer-github-handles.sh>` for an ex
     email = "stephane.tzvetkov@cea.fr";
     name = "Stéphane Tzvetkov";
   };
+  agaget = {
+    email = "alexis.gaget@cea.fr";
+    name = "Alexis Gaget";
+  };
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -28,6 +28,7 @@ in
         asyn = callPackage ./epnix/support/asyn {};
         autosave = callPackage ./epnix/support/autosave {};
         calc = callPackage ./epnix/support/calc {};
+        devlib2 = callPackage ./epnix/support/devlib2 {};
         epics-systemd = callPackage ./epnix/support/epics-systemd {};
         ipac = callPackage ./epnix/support/ipac {};
         modbus = callPackage ./epnix/support/modbus {};

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -32,6 +32,7 @@ in
         epics-systemd = callPackage ./epnix/support/epics-systemd {};
         ipac = callPackage ./epnix/support/ipac {};
         modbus = callPackage ./epnix/support/modbus {};
+        mrfioc2 = callPackage ./epnix/support/mrfioc2 {};
         pvxs = callPackage ./epnix/support/pvxs {};
         seq = callPackage ./epnix/support/seq {};
         snmp = callPackage ./epnix/support/snmp {};

--- a/pkgs/epnix/support/devlib2/default.nix
+++ b/pkgs/epnix/support/devlib2/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  epnixLib,
+  mkEpicsPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  local_config_site ? {},
+  local_release ? {},
+}:
+mkEpicsPackage rec {
+  pname = "devlib2";
+  version = "2.12";
+  varname = "DEVLIB2";
+  #tests seems to need a PCI device to be validated.
+  doCheck = false;
+
+  inherit local_config_site local_release;
+
+  src = fetchFromGitHub {
+    owner = "epics-modules";
+    repo = "devlib2";
+    rev = version;
+    sha256 = "sha256-5rjilz+FO6ZM+Hn7AVwyFG2WWBoBUQA4WW5OHhhdXw4=";
+  };
+
+  meta = {
+    description = "devLib2 - Library for direct MMIO access to PCI and VME64x";
+    homepage = "https://github.com/epics-modules/devlib2";
+    license = epnixLib.licenses.epics;
+    maintainers = with epnixLib.maintainers; [agaget];
+  };
+}

--- a/pkgs/epnix/support/mrfioc2/default.nix
+++ b/pkgs/epnix/support/mrfioc2/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  epnix,
+  epnixLib,
+  mkEpicsPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  local_config_site ? {},
+  local_release ? {},
+}:
+mkEpicsPackage rec {
+  pname = "mrfioc2";
+  version = "2.6.0";
+  varname = "MRFIOC2";
+
+  inherit local_config_site local_release;
+
+  src = fetchFromGitHub {
+    owner = "epics-modules";
+    repo = "mrfioc2";
+    rev = version;
+    sha256 = "sha256-pmuM4HrHlZ63BcZACZOlMAPic1IOQ/kLpi9lo/raP0U=";
+  };
+
+  propagatedBuildInputs = with epnix.support; [devlib2];
+
+  postInstall = ''
+    if [[ -d iocBoot ]]; then
+      cp -rafv iocBoot -t "$out"
+    fi
+  '';
+
+  meta = {
+    description = "Driver EPICS for MRF cards";
+    homepage = "https://github.com/epics-modules/mrfioc2";
+    license = epnixLib.licenses.epics;
+    maintainers = with epnixLib.maintainers; [agaget];
+  };
+}


### PR DESCRIPTION
Using of the standard driver, customs modifications from CEA will be included at one point one day. It is not necessary for standard using.

In draft, because it needs to be tested with hardware.