### PR TITLE
phoebus: 4.7.2 -> 4.7.3

### DIFF
--- a/nixos/tests/phoebus/save-and-restore.py
+++ b/nixos/tests/phoebus/save-and-restore.py
@@ -8,11 +8,13 @@ JSON = str | int | float | bool | None | Dict[str, Any] | List[Any]
 root_node_id = "44bef5de-e8e6-4014-af37-b8f6c8a939a2"
 user = "myself"
 
+base_url = "http://server:8080/save-restore"
+
 
 def get(uri: str):
     return json.loads(
         client.succeed(
-            "curl -sSf " "-H 'Accept: application/json' " f"'http://server:8080{uri}'"
+            "curl -sSf " "-H 'Accept: application/json' " f"'{base_url}{uri}'"
         )
     )
 
@@ -25,7 +27,7 @@ def put(uri: str, data: JSON):
             "-X PUT "
             "-H 'Content-Type: application/json' "
             "-H 'Accept: application/json' "
-            f"'http://server:8080{uri}' "
+            f"'{base_url}{uri}' "
             f"--data '{encoded_data}'"
         )
     )
@@ -37,7 +39,7 @@ def delete(uri: str):
         "-X DELETE "
         "-H 'Content-Type: application/json' "
         "-H 'Accept: application/json' "
-        f"'http://server:8080{uri}'"
+        f"'{base_url}{uri}'"
     )
 
 

--- a/pkgs/epnix/tools/phoebus/deps/default.nix
+++ b/pkgs/epnix/tools/phoebus/deps/default.nix
@@ -8,13 +8,13 @@
 }:
 stdenv.mkDerivation {
   pname = "phoebus-deps";
-  version = "4.7.2";
+  version = "4.7.3";
 
   src = fetchFromGitHub {
     owner = "ControlSystemStudio";
     repo = "phoebus";
-    rev = "v4.7.2";
-    hash = "sha256-UdfwQaOFvx+Ox68P2WuI8sN4eUmyW2WmoVKBj9ZzMXc=";
+    rev = "v4.7.3";
+    hash = "sha256-1Q66iZ+mTXzQ9pjW5wypG7q7rPy9K+PUcQXsKKk2sNo=";
   };
 
   nativeBuildInputs = [jdk maven];
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "sha256-HFrdvjuImn77y2TJvOTxJUFQSwP3umIPklpqI4feplY=";
+  outputHash = "sha256-9MJdmIVAqjPW5ihZYWCh+zsWlxrtoHBH7NFwPh01pRc=";
 
   doCheck = false;
 


### PR DESCRIPTION
This upgrades Phoebus client, alarm-logger, alarm-server, archive-engine, olog, pva, save-and-restore, and scan-server.

With a fix, apparently the default base URL for Phoebus save-and-restore changed from `http//localhost:8080/` to `http//localhost:8080/save-restore/`

cc @lcaouen