### PR TITLE
nixos/local-kafka: always configure replication factor

### DIFF
--- a/nixos/modules/phoebus/local-kafka.nix
+++ b/nixos/modules/phoebus/local-kafka.nix
@@ -11,7 +11,7 @@
     # TODO: document replication setup
     services.apache-kafka = {
       logDirs = lib.mkDefault ["/var/lib/apache-kafka"];
-      extraProperties = lib.mkDefault ''
+      extraProperties = ''
         offsets.topic.replication.factor=1
         transaction.state.log.replication.factor=1
         transaction.state.log.min.isr=1


### PR DESCRIPTION
documentation recommends changing `extraProperties`, which overrides the properties defined here,
which makes Kafka complains that the replication factor can't be applied.

cc @lcaouen for review.