### PR TITLE
ioc/modules/nixos-integration: change Restart systemd option to always

### DIFF
--- a/ioc/modules/nixos-integration.nix
+++ b/ioc/modules/nixos-integration.nix
@@ -110,7 +110,7 @@ in {
               ${toString config.procServ.port} \
               ${iocTop}/bin/${arch}/${config.app} ${config.startCommandsFile}
             '';
-            Restart = "on-failure";
+            Restart = "always";
           };
         };
       }));


### PR DESCRIPTION
sometimes `procServ` exits cleanly, even though the IOC was killed by a signal (e.g. `SIGSEGV`). The IOC should restart in that case.