### PR TITLE
Fix support imports and exports

### DIFF
--- a/ioc/modules/common.nix
+++ b/ioc/modules/common.nix
@@ -27,7 +27,7 @@ with lib; {
           ~ The actual build of this distribution.
       '';
       default = {};
-      type = types.attrs;
+      type = with types; attrsOf package;
     };
 
     epnix.pkgs = mkOption {

--- a/lib/evaluation.nix
+++ b/lib/evaluation.nix
@@ -1,0 +1,95 @@
+{
+  inputs,
+  lib,
+  ...
+}: let
+  evalEpnixModules' = {
+    epnixConfig,
+    epnixFunEval,
+    pkgs,
+  }: let
+    eval = lib.evalModules {
+      modules = [
+        ({config, ...}: {
+          config._module.args = {
+            pkgs = pkgs config;
+
+            # Used when we want to apply the same config in checks
+            inherit epnixConfig;
+            inherit epnixFunEval;
+          };
+        })
+
+        epnixConfig
+        inputs.self.nixosModules.ioc
+
+        # nixpkgs and assertions are separate, in case we want to include
+        # this module in a NixOS configuration, where `nixpkgs` and
+        # `assertions` options are already defined
+        ../ioc/modules/nixpkgs.nix
+        ../ioc/modules/assertions.nix
+      ];
+    };
+
+    # From Robotnix
+    # From nixpkgs/nixos/modules/system/activation/top-level.nix
+    failedAssertions = map (x: x.message) (lib.filter (x: !x.assertion) eval.config.assertions);
+
+    config =
+      if failedAssertions != []
+      then throw "\nFailed assertions:\n${lib.concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"
+      else lib.showWarnings eval.config.warnings eval.config;
+  in {
+    inherit (eval) options;
+    inherit config;
+
+    inherit (config.epnix) outputs generatedOverlay;
+  };
+
+  self = {
+    evalEpnixModules = {
+      nixpkgsConfig,
+      epnixConfig,
+    }: let
+      nixpkgsConfigWithDefaults =
+        {
+          crossSystem = null;
+          config = {};
+        }
+        // nixpkgsConfig;
+
+      pkgs = config:
+        (import inputs.nixpkgs {
+          inherit (nixpkgsConfigWithDefaults) system crossSystem config;
+          inherit (config.nixpkgs) overlays;
+        })
+        # See: https://github.com/NixOS/nixpkgs/pull/190358
+        .__splicedPackages;
+
+      # As a function,
+      # so that we can import the package without fixing the dependencies.
+      #
+      # This is needed because,
+      # if this package is an EPICS support module,
+      # it needs to *not* depend on a specific version of epics-base.
+      #
+      # It needs to use the same version of epics-base
+      # that is going to be used by the final IOC.
+      epnixFunEval = pkgs:
+        evalEpnixModules' {
+          inherit epnixConfig epnixFunEval;
+          pkgs = config: pkgs;
+        };
+
+      fixedEval = evalEpnixModules' {inherit epnixConfig epnixFunEval pkgs;};
+    in
+      fixedEval;
+
+    mkEpnixBuild = cfg:
+      (self.evalEpnixModules cfg).config.epnix.outputs.build;
+
+    mkEpnixDevShell = cfg:
+      (self.evalEpnixModules cfg).config.epnix.outputs.devShell;
+  };
+in
+  self

--- a/templates/top/flake.nix
+++ b/templates/top/flake.nix
@@ -4,6 +4,14 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.epnix.url = "github:epics-extensions/epnix";
 
+  # If you have a support module as a separate EPNix repository,
+  # add it as an input here:
+  # ---
+  #inputs.mySupportModule = {
+  #  url = "git+ssh://git@my-server.org/me/exampleApp.git";
+  #  inputs.epnix.follows = "epnix";
+  #};
+
   # If you have an "App" as a separate repository,
   # add it as an input here:
   # ---
@@ -18,9 +26,14 @@
     epnix,
     ...
   } @ inputs: let
-    myEpnixDistribution = {pkgs, ...}: {
+    myEpnixConfig = {pkgs, ...}: {
       # Set your EPNix options here
       # ---
+
+      # If you have a support module as a separate EPNix repository,
+      # uncomment this line to make the package available:
+      # ---
+      #overlays = [inputs.mySupportModule.overlays.default];
 
       epnix = {
         inherit inputs;
@@ -33,9 +46,9 @@
         # ---
         #epics-base.releaseBranch = "3"; # Defaults to "7"
 
-        # Add one of the supported modules here:
+        # Add your support modules here:
         # ---
-        #support.modules = with pkgs.epnix.support; [ StreamDevice ];
+        #support.modules = with pkgs.epnix.support; [ StreamDevice mySupportModule ];
 
         # If you have an "App" as a separate repository,
         # add it here:
@@ -69,7 +82,7 @@
     # environment can be built on your machine.
     flake-utils.lib.eachSystem ["x86_64-linux"] (system:
       with epnix.lib; let
-        result = evalEpnixModules {
+        epnixDistribution = evalEpnixModules {
           nixpkgsConfig = {
             # This specifies the build architecture
             inherit system;
@@ -81,17 +94,23 @@
             # ---
             #crossSystem = epnix.inputs.nixpkgs.lib.systems.examples.armv7l-hf-multiplatform;
           };
-          epnixConfig = myEpnixDistribution;
+          epnixConfig = myEpnixConfig;
         };
       in {
         packages =
-          result.outputs
+          epnixDistribution.outputs
           // {
             default = self.packages.${system}.build;
           };
 
+        inherit epnixDistribution;
+
         devShells.default = self.packages.${system}.devShell;
 
-        checks = result.config.epnix.checks.derivations;
-      });
+        checks = epnixDistribution.config.epnix.checks.derivations;
+      })
+    // {
+      overlays.default = final: prev:
+        self.epnixDistribution.x86_64-linux.generatedOverlay final prev;
+    };
 }


### PR DESCRIPTION
Before this PR, this was only supported to import an EPNix top as support module by importing its pre-configured package. This meant that it was annoying to have the same version of its dependencies (and epics-base refuses if there are different versions), and it was near impossible to setup cross-compilation with an EPNix support module.

This PR solves everything.

Best viewed commit by commit.

See the `templates/top` commit for how to use it, and how to update your `flake.nix` files.