### PR TITLE
Add adsDriver and autoparamDriver

### DIFF
--- a/lib/maintainers/maintainer-list.nix
+++ b/lib/maintainers/maintainer-list.nix
@@ -66,4 +66,10 @@ See `<nixpkgs/maintainers/scripts/check-maintainer-github-handles.sh>` for an ex
     email = "stephane.tzvetkov@cea.fr";
     name = "Stéphane Tzvetkov";
   };
+  synthetica = {
+    email = "philhorst@highvolteng.com";
+    name = "Patrick Hilhorst";
+    github = "Synthetica9";
+    githubId = 7075751;
+  };
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -31,6 +31,7 @@ in
 
       support = recurseExtensible (_self: {
         asyn = callPackage ./epnix/support/asyn {};
+        autoparamDriver = callPackage ./epnix/support/autoparamDriver {};
         autosave = callPackage ./epnix/support/autosave {};
         calc = callPackage ./epnix/support/calc {};
         devlib2 = callPackage ./epnix/support/devlib2 {};

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -30,6 +30,7 @@ in
       # EPICS support modules
 
       support = recurseExtensible (_self: {
+        adsDriver = callPackage ./epnix/support/adsDriver {};
         asyn = callPackage ./epnix/support/asyn {};
         autoparamDriver = callPackage ./epnix/support/autoparamDriver {};
         autosave = callPackage ./epnix/support/autosave {};

--- a/pkgs/epnix/support/adsDriver/default.nix
+++ b/pkgs/epnix/support/adsDriver/default.nix
@@ -1,0 +1,36 @@
+{
+  mkEpicsPackage,
+  fetchFromGitHub,
+  epnix,
+  boost,
+  epnixLib,
+  lib,
+}:
+mkEpicsPackage rec {
+  pname = "adsDriver";
+  version = "3.1.0";
+
+  varname = "ADS_DRIVER";
+
+  src = fetchFromGitHub {
+    owner = "Cosylab";
+    repo = pname;
+    rev = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-Ruzi+H8MmIgv23pzFXZlvkk3HtbDzQ9LTTVzmeGWrSI==";
+  };
+
+  nativeBuildInputs = [boost];
+  buildInputs = [boost];
+  propagatedBuildInputs = with epnix.support; [
+    asyn
+    autoparamDriver
+  ];
+
+  meta = {
+    description = "EPICS support module for integrating Beckhoff PLC using the ADS protocol";
+    homepage = "https://epics.cosylab.com/documentation/adsDriver/";
+    license = lib.licenses.mit;
+    maintainers = with epnixLib.maintainers; [synthetica];
+  };
+}

--- a/pkgs/epnix/support/autoparamDriver/default.nix
+++ b/pkgs/epnix/support/autoparamDriver/default.nix
@@ -1,0 +1,29 @@
+{
+  mkEpicsPackage,
+  fetchFromGitHub,
+  epnix,
+  lib,
+  epnixLib,
+}:
+mkEpicsPackage rec {
+  pname = "autoparamDriver";
+  version = "2.0.0";
+
+  varname = "AUTOPARAM";
+
+  src = fetchFromGitHub {
+    owner = "Cosylab";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-J2fy/pMwrbwVFULfANuJBl6iE3wju5bQkhkxxk8zRYs=";
+  };
+
+  propagatedBuildInputs = with epnix.support; [asyn];
+
+  meta = {
+    description = "An asyn driver that creates parameters dynamically based on content of record links";
+    homepage = "https://epics.cosylab.com/documentation/autoparamDriver/";
+    license = lib.licenses.mit;
+    maintainers = with epnixLib.maintainers; [synthetica];
+  };
+}


### PR DESCRIPTION
Add adsDriver (https://epics.cosylab.com/documentation/adsDriver/) and autoParamDriver (dependency, https://epics.cosylab.com/documentation/autoparamDriver)

I'm not sure what is meant with the mandatory varname attribute (fairly new to EPICS) so I'm not sure if I got those correct, would like review on that.

Added myself as maintainer for these two.

