### PR TITLE
gitlab-ci: make pipeline/jobs interruptible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,9 @@
+workflow:
+  auto_cancel:
+    on_new_commit: interruptible
+
 default:
+  interruptible: true
   tags:
     - nix
 


### PR DESCRIPTION
So that on our GitLab, pushing to a branch cancel running jobs from previous commits. Should make our poor, poor build server use less resources.