### PR TITLE
Archiver appliance: move to new owner

### DIFF
--- a/pkgs/epnix/tools/archiver-appliance/default.nix
+++ b/pkgs/epnix/tools/archiver-appliance/default.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation (self: {
   version = "1.1.0";
 
   src = fetchFromGitHub {
-    owner = "slacmshankar";
+    owner = "archiver-appliance";
     repo = "epicsarchiverap";
     rev = self.version;
     fetchSubmodules = true;


### PR DESCRIPTION
Archiver appliance got its own github namespace, which causes our build to fail. 