### PR TITLE
upgrade NixOS 23.11 -> 24.05

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ which is considered unstable,
 meaning breaking changes might happen without notice.
 
 EPNix also has release branches,
-such as ``nixos-23.11``,
+such as ``nixos-24.05``,
 tied to the nixpkgs release branches,
 where breaking changes are forbidden.
 

--- a/docs/nixos-services/tutorials/archiver-appliance.rst
+++ b/docs/nixos-services/tutorials/archiver-appliance.rst
@@ -61,8 +61,8 @@ Fill the file with these lines:
    {
      description = "Configuration for running Archiver Appliance in a VM";
 
-     inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
-     inputs.epnix.url = "github:epics-extensions/EPNix/nixos-23.11";
+     inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+     inputs.epnix.url = "github:epics-extensions/EPNix/nixos-24.05";
 
      outputs = { self, nixpkgs, epnix }: {
        nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {

--- a/docs/nixos-services/user-guides/pre-requisites.rst
+++ b/docs/nixos-services/user-guides/pre-requisites.rst
@@ -21,8 +21,8 @@ For example:
 
     {
       # ...
-      inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
-   +  inputs.epnix.url = "github:epics-extensions/EPNix/nixos-23.11";
+      inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+   +  inputs.epnix.url = "github:epics-extensions/EPNix/nixos-24.05";
 
       # ...
       outputs = {

--- a/flake.lock
+++ b/flake.lock
@@ -95,16 +95,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720535198,
-        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "lastModified": 1722221733,
+        "narHash": "sha256-sga9SrrPb+pQJxG1ttJfMPheZvDOxApFfwXCFO0H9xw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "rev": "12bf09802d77264e441f48e25459c10c93eada2e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A Nix flake containing EPICS-related modules and packages";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     bash-lib = {
       url = "github:minijackson/bash-lib";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -56,7 +56,7 @@ in
         ipac = callPackage ./epnix/support/ipac {};
         modbus = callPackage ./epnix/support/modbus {};
         mrfioc2 = callPackage ./epnix/support/mrfioc2 {};
-        opcua = callPackage ./epnix/support/opcua {};
+        opcua = callPackage ./epnix/support/opcua {open62541 = self.open62541_1_3;};
         pvxs = callPackage ./epnix/support/pvxs {};
         seq = callPackage ./epnix/support/seq {};
         snmp = callPackage ./epnix/support/snmp {};
@@ -91,6 +91,8 @@ in
       # Other utilities
 
       mariadb_jdbc = callPackage ./epnix/tools/mariadb_jdbc {};
+      # Needed by support/opcua
+      open62541_1_3 = callPackage ./epnix/tools/open62541_1_3 {};
 
       # EPNix specific packages
       docs = callPackage ./docs {};

--- a/pkgs/docs/default.nix
+++ b/pkgs/docs/default.nix
@@ -70,7 +70,7 @@
 in
   stdenvNoCC.mkDerivation {
     pname = "epnix-docs";
-    version = "23.11";
+    version = "24.05";
 
     src = ../../docs;
 

--- a/pkgs/epnix/kernel-modules/mrf/default.nix
+++ b/pkgs/epnix/kernel-modules/mrf/default.nix
@@ -1,13 +1,22 @@
 {
   stdenv,
-  lib,
   kernel,
   epnix,
+  fetchpatch,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "mrf-driver";
 
   inherit (epnix.support.mrfioc2) version src;
+
+  patches = [
+    (fetchpatch {
+      name = "use-vm_flags_set-on-kernels-6-3.patch";
+      url = "https://github.com/epics-modules/mrfioc2/commit/64634a23a035d336de5d720b2e1ecafcc918d737.patch";
+      hash = "sha256-6/obmLfLKfhcwn12O0KKpogWCzg7Evs1kIoNm0x7Puw=";
+      stripLen = 2;
+    })
+  ];
 
   # Needed for kernel modules
   hardeningDisable = ["format" "pic"];

--- a/pkgs/epnix/support/twincat-ads/default.nix
+++ b/pkgs/epnix/support/twincat-ads/default.nix
@@ -23,6 +23,9 @@ mkEpicsPackage rec {
     sha256 = "sha256-f7hod1N1AzCh+W7nHl9VCA+nuwpJAboSh19Dq80n/2E=";
   };
 
+  # See: https://gitlab.esss.lu.se/epics-modules/epics-twincat-ads/-/issues/2
+  patches = [./fix-missing-header.patch];
+
   propagatedBuildInputs = with epnix.support; [asyn calc];
 
   preBuild = ''

--- a/pkgs/epnix/support/twincat-ads/fix-missing-header.patch
+++ b/pkgs/epnix/support/twincat-ads/fix-missing-header.patch
@@ -1,0 +1,13 @@
+diff --git a/BeckhoffADS/AdsLib/AdsLib.cpp b/BeckhoffADS/AdsLib/AdsLib.cpp
+index f1b2116..8a82a95 100644
+--- a/BeckhoffADS/AdsLib/AdsLib.cpp
++++ b/BeckhoffADS/AdsLib/AdsLib.cpp
+@@ -20,6 +20,8 @@
+    SOFTWARE.
+  */
+ 
++#include <stdexcept>
++
+ #include "AdsLib.h"
+ #include "AmsRouter.h"
+ 

--- a/pkgs/epnix/tools/open62541_1_3/default.nix
+++ b/pkgs/epnix/tools/open62541_1_3/default.nix
@@ -1,0 +1,177 @@
+{
+  stdenv,
+  lib,
+  epnixLib,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  check,
+  libxcrypt,
+  subunit,
+  python3Packages,
+  nix-update-script,
+  withDoc ? false,
+  graphviz-nox,
+  withExamples ? false,
+  withEncryption ? false, # or "openssl" or "mbedtls"
+  openssl,
+  mbedtls,
+  withPubSub ? false,
+  # for passthru.tests only
+  open62541,
+}: let
+  encryptionBackend =
+    {
+      inherit openssl mbedtls;
+    }
+    ."${withEncryption}"
+    or (throw "Unsupported encryption backend: ${withEncryption}");
+in
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "open62541";
+    version = "1.3.10";
+
+    src = fetchFromGitHub {
+      owner = "open62541";
+      repo = "open62541";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-FekO0cKgpYulMXz4r0/TUPz2tawC4k3Sq07Og4xqh4I=";
+      fetchSubmodules = true;
+    };
+
+    patches = [
+      (fetchpatch {
+        name = "Ensure-absolute-paths-in-pkg-config-file.patch";
+        url = "https://github.com/open62541/open62541/commit/023d4b6b8bdec987f8f3ffee6c09801bbee4fa2d.patch";
+        sha256 = "sha256-mq4h32js2RjI0Ljown/01SXA3gc+7+zX8meIcvDPvoA=";
+      })
+    ];
+
+    cmakeFlags =
+      [
+        "-DOPEN62541_VERSION=v${finalAttrs.version}"
+
+        "-DBUILD_SHARED_LIBS=${
+          if stdenv.hostPlatform.isStatic
+          then "OFF"
+          else "ON"
+        }"
+        "-DUA_NAMESPACE_ZERO=FULL"
+
+        "-DUA_BUILD_UNIT_TESTS=${
+          if finalAttrs.doCheck
+          then "ON"
+          else "OFF"
+        }"
+      ]
+      ++ lib.optional withExamples "-DUA_BUILD_EXAMPLES=ON"
+      ++ lib.optional (withEncryption != false)
+      "-DUA_ENABLE_ENCRYPTION=${lib.toUpper withEncryption}"
+      ++ lib.optional withPubSub "-DUA_ENABLE_PUBSUB=ON";
+
+    nativeBuildInputs =
+      [
+        cmake
+        pkg-config
+        python3Packages.python
+      ]
+      ++ lib.optionals withDoc (with python3Packages; [
+        sphinx
+        sphinx_rtd_theme
+        graphviz-nox
+      ]);
+
+    buildInputs = lib.optional (withEncryption != false) encryptionBackend;
+
+    buildFlags = ["all"] ++ lib.optional withDoc "doc";
+
+    doCheck = true;
+
+    checkInputs = [
+      check
+      libxcrypt
+      subunit
+    ];
+
+    # Tests must run sequentially to avoid port collisions on localhost
+    enableParallelChecking = false;
+
+    preCheck = let
+      disabledTests = lib.optionals withPubSub [
+        # "Cannot set socket option IP_ADD_MEMBERSHIP"
+        "pubsub_publish"
+        "check_pubsub_get_state"
+        "check_pubsub_publish_rt_levels"
+        "check_pubsub_subscribe_config_freeze"
+        "check_pubsub_subscribe_rt_levels"
+        "check_pubsub_multiple_subscribe_rt_levels"
+      ];
+      regex = "^(${builtins.concatStringsSep "|" disabledTests})\$";
+    in
+      lib.optionalString (disabledTests != []) ''
+        checkFlagsArray+=(ARGS="-E ${lib.escapeRegex regex}")
+      '';
+
+    postInstall =
+      lib.optionalString withDoc ''
+        # excluded files, see doc/CMakeLists.txt
+        rm -r doc/{_sources/,CMakeFiles/,cmake_install.cmake}
+
+        # doc is not installed automatically
+        mkdir -p $out/share/doc/open62541
+        cp -r doc/ $out/share/doc/open62541/html
+      ''
+      + lib.optionalString withExamples ''
+        # install sources of examples
+        mkdir -p $out/share/open62541
+        cp -r ../examples $out/share/open62541
+
+        ${lib.optionalString (!stdenv.hostPlatform.isWindows) ''
+          # remove .exe suffix
+          mv -v $out/bin/ua_server_ctt.exe $out/bin/ua_server_ctt
+        ''}
+
+        # remove duplicate libraries in build/bin/, which cause forbidden
+        # references to /build/ in ua_server_ctt
+        rm -r bin/libopen62541*
+      '';
+
+    passthru.updateScript = nix-update-script {};
+
+    passthru.tests = let
+      open62541Full = encBackend:
+        open62541.override {
+          withDoc = true;
+          # if (withExamples && withPubSub), one of the example currently fails to build
+          #withExamples = true;
+          withEncryption = encBackend;
+          withPubSub = true;
+        };
+    in {
+      open62541Full = open62541Full false;
+      open62541Full-openssl = open62541Full "openssl";
+      open62541Full-mbedtls = open62541Full "mbedtls";
+    };
+
+    meta = with lib; {
+      description = "Open source implementation of OPC UA, version 1.3";
+      longDescription = ''
+        open62541 (http://open62541.org) is an open source and free implementation
+        of OPC UA (OPC Unified Architecture) written in the common subset of the
+        C99 and C++98 languages.
+        The library is usable with all major compilers and provides the necessary
+        tools to implement dedicated OPC UA clients and servers, or to integrate
+        OPC UA-based communication into existing applications.
+
+        This version of Open62541 was added in EPNix, as a stopgap measure,
+        while waiting for the EPICS OPCUA support module to support the
+        breaking changes made in 1.4.
+      '';
+      homepage = "https://www.open62541.org";
+      changelog = "https://github.com/open62541/open62541/releases/tag/v${finalAttrs.version}";
+      license = licenses.mpl20;
+      maintainers = with epnixLib.maintainers; [minijackson];
+      platforms = platforms.linux;
+    };
+  })

--- a/pkgs/epnix/tools/phoebus/deps/default.nix
+++ b/pkgs/epnix/tools/phoebus/deps/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "sha256-6pUHn6tU54e4r5tJwoailVX3YEqO9BouWM3fweAdyt8=";
+  outputHash = "sha256-tJMULUSwH0rCmNeKvesPqMVTBH3PQWInx6gzGxwdPwY=";
 
   doCheck = false;
 

--- a/templates/top/flake.nix
+++ b/templates/top/flake.nix
@@ -2,7 +2,7 @@
   description = "EPICS IOC for <...>";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.epnix.url = "github:epics-extensions/epnix/nixos-23.11";
+  inputs.epnix.url = "github:epics-extensions/epnix/nixos-24.05";
 
   # If you have a support module as a separate EPNix repository,
   # add it as an input here:


### PR DESCRIPTION
and related changes to documentation and templates, and to the Phoebus deps output hash.

Currently draft, because the opcua EPICS module is currently not compatible with `libopen62541 >= 1.4.0`