### PR TITLE
epics-base7: 7.0.8 -> 7.0.8.1

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -18,8 +18,8 @@ in
       # EPICS base
 
       epics-base7 = callPackage ./epnix/epics-base {
-        version = "7.0.8";
-        hash = "sha256-GEkUwlOkRhQ6LskxHV+eDvBe9UUzF2YWWmgiyuiHypM=";
+        version = "7.0.8.1";
+        hash = "sha256-JDSMBwBLZj9aaxJHGg0QmZ1zYTSY8J7+ZGihAwEuz3w=";
       };
       epics-base3 = callPackage ./epnix/epics-base {
         version = "3.15.9";

--- a/pkgs/epnix/epics-base/default.nix
+++ b/pkgs/epnix/epics-base/default.nix
@@ -136,10 +136,14 @@ in
     # TODO: Some tests fail
     doCheck = false;
 
-    # _FORTIFY_SOURCE=3 causes a buffer overflow in some cases:
+    # _FORTIFY_SOURCE=3 detects a false-positive buffer overflow in some cases:
     #     *** buffer overflow detected ***: terminated
     #
-    # Fall back to _FORTIFY_SOURCE=2
+    # EPICS automatically falls back to _FORTIFY_SOURCE=2 since 7.0.8.1, but this doesn't work in
+    # the nix build.
+    # Being tracked in https://github.com/epics-base/epics-base/issues/514, hopefully with a fix
+    # in EPICS 7.0.9
+
     hardeningDisable = ["fortify3"];
 
     meta = {


### PR DESCRIPTION
Most relevant for this project: the fortify-source issue was worked around, will probably be fixed in the next minor version.

Do we want to keep in the fortify3 disable for backwards source compatibility or remove it for forwards compatibility?