### PR TITLE
linuxPackages.mrf: init at 2.6.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             constituents = builtins.attrValues self.packages.${system};
           };
         }
+        // (import ./pkgs/tests {inherit pkgs self;})
         // (import ./ioc/tests {inherit pkgs self;})
         // (import ./nixos/tests/all-tests.nix {inherit nixpkgs pkgs self system;});
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14,6 +14,15 @@ in
       scanf = final.callPackage ./epnix/tools/scanf {};
     });
 
+    linuxKernel =
+      prev.linuxKernel
+      // {
+        packagesFor = kernel:
+          (prev.linuxKernel.packagesFor kernel).extend (final: _prev: {
+            mrf = final.callPackage ./epnix/kernel-modules/mrf {};
+          });
+      };
+
     epnix = recurseExtensible (self: {
       # EPICS base
 

--- a/pkgs/epnix/kernel-modules/mrf/default.nix
+++ b/pkgs/epnix/kernel-modules/mrf/default.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  lib,
+  kernel,
+  epnix,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mrf-driver";
+
+  inherit (epnix.support.mrfioc2) version src;
+
+  # Needed for kernel modules
+  hardeningDisable = ["format" "pic"];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  enableParallelBuilding = true;
+
+  setSourceRoot = ''
+    export sourceRoot="$(pwd)/${finalAttrs.src.name}/mrmShared/linux";
+  '';
+
+  makeFlags =
+    kernel.makeFlags
+    ++ [
+      "-C"
+      "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      "KERNELRELEASE=${kernel.modDirVersion}"
+      "INSTALL_MOD_PATH=$(out)"
+      "VERSION=${finalAttrs.version}"
+      "M=$(sourceRoot)"
+      # Uncomment this line to enable debugging
+      # "KCFLAGS=-DDBG"
+    ];
+
+  buildFlags = ["modules"];
+  installTargets = ["modules_install"];
+
+  meta = {
+    description = "MRF kernel driver";
+    inherit (epnix.support.mrfioc2.meta) homepage license maintainers;
+  };
+})

--- a/pkgs/tests/default.nix
+++ b/pkgs/tests/default.nix
@@ -1,0 +1,8 @@
+# For packages that are not directly exposed to the user,
+# but should still work.
+#
+# For example kernel modules, which depend on the kernel version,
+# or Python libraries, which depend on the Python version.
+{pkgs, ...}: {
+  mrf-driver-default-linux = pkgs.linuxPackages.mrf;
+}


### PR DESCRIPTION
Pinging @agaget for testing it on real hardware.

To add the module, make sure you [import EPNix](https://github.com/epics-extensions/EPNix/blob/master/doc/nixos/guides/_pre-requisites.md), and you should be able to set `boot.kernelModules = ["mrf"];`

I'll have to add that exact documentation later.