### PR TITLE
github: init Update flake.lock action

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,37 @@
+name: Update flake.lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+
+# WARNING:
+# When extending this action, be aware that $GITHUB_TOKEN allows write access to
+# the GitHub repository. This means that it should not evaluate user input in a
+# way that allows code injection.
+
+permissions:
+  contents: read
+
+jobs:
+  lockfile:
+    strategy:
+      matrix:
+        branch:
+          - master
+          - nixos-23.11
+          - nixos-23.05
+    permissions:
+      contents: write # to create branch
+      pull-requests: write # to create PR to backport
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ matrix.branch }}
+      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
+      - uses: DeterminateSystems/update-flake-lock@db4ee38117a597ea8df8f7f75a187dd65093eade # v23
+        with:
+          branch: "update-flake-lock/${{ matrix.branch }}"
+          pr-title: "[${{ matrix.branch }}] Update flake.lock"
+          pr-labels: |
+            dependencies


### PR DESCRIPTION
So that we stay up-to-date, even inside a release branch.

This will create a PR weekly (or on demand) that proposes the result of a `nix flake update --commit-lock-file` for the EPNix repository, on each release branch.