### PR TITLE
phoebus-client: hardcode Python path for the console view

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -67,11 +67,7 @@ in
 
       pcas = callPackage ./epnix/tools/pcas {};
 
-      phoebus = callPackage ./epnix/tools/phoebus/client {
-        # TODO: uncomment when this works:
-        # TODO: add libjfxwebkit.so into openjfx
-        # jdk = final.openjdk17.override {enableJavaFX = true;};
-      };
+      phoebus = callPackage ./epnix/tools/phoebus/client {};
       phoebus-alarm-server = callPackage ./epnix/tools/phoebus/alarm-server {};
       phoebus-alarm-logger = callPackage ./epnix/tools/phoebus/alarm-logger {};
       phoebus-archive-engine = callPackage ./epnix/tools/phoebus/archive-engine {};

--- a/pkgs/epnix/tools/phoebus/client/default.nix
+++ b/pkgs/epnix/tools/phoebus/client/default.nix
@@ -2,6 +2,7 @@
   lib,
   epnixLib,
   stdenv,
+  substituteAll,
   maven,
   makeWrapper,
   makeDesktopItem,
@@ -9,12 +10,20 @@
   epnix,
   jdk,
   openjfx,
+  python3,
 }: let
   buildDate = "2022-02-24T07:56:00Z";
 in
   stdenv.mkDerivation {
     pname = "phoebus";
     inherit (epnix.phoebus-deps) version src;
+
+    patches = [
+      (substituteAll {
+        src = ./fix-python-path.patch;
+        python = lib.getExe python3;
+      })
+    ];
 
     # TODO: make a scope, so that we don't pass around the whole `epnix`
     nativeBuildInputs = [
@@ -30,6 +39,14 @@ in
           };
         };
       })
+    ];
+
+    # Put runtime dependencies in propagated
+    # because references get thrown into a jar
+    # which is compressed,
+    # so the Nix scanner won't always be able to see them
+    propagatedBuildInputs = [
+      python3
     ];
 
     desktopItems = [

--- a/pkgs/epnix/tools/phoebus/client/default.nix
+++ b/pkgs/epnix/tools/phoebus/client/default.nix
@@ -55,15 +55,14 @@ in
         exec = "phoebus -server 4918 -resource %f";
         desktopName = "Phoebus";
         keywords = ["epics" "css"];
+        # https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html#category-registry
         categories = [
+          # Main
           "Office"
-          "Graphics"
-          "GUIDesigner"
-          "Viewer"
-          "Science"
-          "Physics"
-          "Monitor"
+
+          # Additional
           "Java"
+          "Viewer"
         ];
       })
     ];

--- a/pkgs/epnix/tools/phoebus/client/fix-python-path.patch
+++ b/pkgs/epnix/tools/phoebus/client/fix-python-path.patch
@@ -1,0 +1,17 @@
+diff --git a/app/console/src/main/resources/console_preferences.properties b/app/console/src/main/resources/console_preferences.properties
+index e00d6f8ec..e3bc52f3e 100644
+--- a/app/console/src/main/resources/console_preferences.properties
++++ b/app/console/src/main/resources/console_preferences.properties
+@@ -28,9 +28,9 @@ prompt_info=Enter console command
+ #   /bin/bash
+ #
+ # Value may include properties.
+-shell=/usr/bin/python -i
++shell=@python@ -i
+ 
+ # Folder where the shell process should be started
+ #
+ # Value may include properties.
+-directory=$(user.home)
+\ No newline at end of file
++directory=$(user.home)


### PR DESCRIPTION
Upstream defaults to /usr/bin/python3, which doesn't exist on NixOS

Fixes #100

And some minor cleanup