### PR TITLE
Use `meta.mainProgram` and `lib.getExe`

### DIFF
--- a/ioc/modules/nixos-integration.nix
+++ b/ioc/modules/nixos-integration.nix
@@ -103,7 +103,7 @@ in {
 
           serviceConfig = {
             ExecStart = let
-              procServ = "${pkgs.epnix.procServ}/bin/procServ";
+              procServ = lib.getExe pkgs.epnix.procServ;
               arch = epnix.lib.toEpicsArch globalConfig.epnix.outputs.build.stdenv.hostPlatform;
             in ''
               ${procServ} ${lib.cli.toGNUCommandLineShell {} config.procServ.options} \

--- a/nixos/modules/ca-gateway.nix
+++ b/nixos/modules/ca-gateway.nix
@@ -182,7 +182,7 @@ in {
       after = ["network-online.target"];
 
       serviceConfig = {
-        ExecStart = "${pkg}/bin/gateway ${commandLine}";
+        ExecStart = "${lib.getExe pkg} ${commandLine}";
         # ca-gateway doesn't always exit with a positive status code,
         # even on failure
         Restart = "always";

--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -146,7 +146,7 @@ in {
             "-noshell"
             "-properties ${configFile}"
           ];
-        in "${pkgs.epnix.phoebus-alarm-logger}/bin/phoebus-alarm-logger ${lib.concatStringsSep " " args}";
+        in "${lib.getExe pkgs.epnix.phoebus-alarm-logger} ${lib.concatStringsSep " " args}";
         DynamicUser = true;
         StateDirectory = "phoebus-alarm-logger";
         # TODO: systemd hardening

--- a/nixos/modules/phoebus/olog.nix
+++ b/nixos/modules/phoebus/olog.nix
@@ -108,7 +108,7 @@ in {
       after = ["elasticsearch.service" "mongodb.service"];
 
       serviceConfig = {
-        ExecStart = "${pkgs.epnix.phoebus-olog}/bin/phoebus-olog --spring.config.location=file://${configFile}";
+        ExecStart = "${lib.getExe pkgs.epnix.phoebus-olog} --spring.config.location=file://${configFile}";
         DynamicUser = true;
         # TODO: systemd hardening. Currently level 8.2 EXPOSED
       };

--- a/nixos/modules/phoebus/save-and-restore.nix
+++ b/nixos/modules/phoebus/save-and-restore.nix
@@ -84,7 +84,7 @@ in {
       after = lib.mkIf localElasticsearch ["elasticsearch.service"];
 
       serviceConfig = {
-        ExecStart = "${pkgs.epnix.phoebus-save-and-restore}/bin/phoebus-save-and-restore --spring.config.location=file://${configFile}";
+        ExecStart = "${lib.getExe pkgs.epnix.phoebus-save-and-restore} --spring.config.location=file://${configFile}";
         Restart = "on-failure";
         DynamicUser = true;
 

--- a/pkgs/epnix/tools/ca-gateway/default.nix
+++ b/pkgs/epnix/tools/ca-gateway/default.nix
@@ -26,6 +26,7 @@ mkEpicsPackage rec {
   meta = {
     description = "Channel Access PV gateway";
     homepage = "https://epics.anl.gov/extensions/gateway/";
+    mainProgram = "gateway";
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [minijackson];
   };

--- a/pkgs/epnix/tools/lewis/default.nix
+++ b/pkgs/epnix/tools/lewis/default.nix
@@ -49,6 +49,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Let's write intricate simulators";
     homepage = "https://github.com/ess-dmsc/lewis";
+    mainProgram = "lewis";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [minijackson];
   };

--- a/pkgs/epnix/tools/phoebus/alarm-logger/default.nix
+++ b/pkgs/epnix/tools/phoebus/alarm-logger/default.nix
@@ -50,6 +50,7 @@ in
     meta = {
       description = "Records all alarm messages to create an archive of all alarm state changes and the associated actions";
       homepage = "https://control-system-studio.readthedocs.io/en/latest/services/alarm-logger/doc/index.html";
+      mainProgram = "phoebus-alarm-logger";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
       inherit (jdk.meta) platforms;

--- a/pkgs/epnix/tools/phoebus/archive-engine/default.nix
+++ b/pkgs/epnix/tools/phoebus/archive-engine/default.nix
@@ -50,6 +50,7 @@ in
     meta = {
       description = "Phoebus' RDB Archive Engine Service";
       homepage = "https://control-system-studio.readthedocs.io/en/latest/services/archive-engine/doc/index.html";
+      mainProgram = "phoebus-archive-engine";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
       inherit (jdk.meta) platforms;

--- a/pkgs/epnix/tools/phoebus/client/default.nix
+++ b/pkgs/epnix/tools/phoebus/client/default.nix
@@ -104,6 +104,7 @@ in
     meta = {
       description = "Control System Studio's Phoebus client";
       homepage = "https://control-system-studio.readthedocs.io/en/latest/index.html";
+      mainProgram = "phoebus";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
       inherit (jdk.meta) platforms;

--- a/pkgs/epnix/tools/phoebus/pva/default.nix
+++ b/pkgs/epnix/tools/phoebus/pva/default.nix
@@ -50,6 +50,7 @@ in
     meta = {
       description = "Phoebus' PV Access client and server";
       homepage = "https://github.com/ControlSystemStudio/phoebus/tree/master/core/pva";
+      mainProgram = "phoebus-pva";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
       inherit (jdk.meta) platforms;

--- a/pkgs/epnix/tools/phoebus/save-and-restore/default.nix
+++ b/pkgs/epnix/tools/phoebus/save-and-restore/default.nix
@@ -50,6 +50,7 @@ in
     meta = {
       description = "Implements the MASAR (MAchine Save And Restore) service as a REST API";
       homepage = "https://control-system-studio.readthedocs.io/en/latest/services/save-and-restore/doc/index.html";
+      mainProgram = "phoebus-save-and-restore";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
       inherit (jdk.meta) platforms;

--- a/pkgs/epnix/tools/phoebus/scan-server/default.nix
+++ b/pkgs/epnix/tools/phoebus/scan-server/default.nix
@@ -50,6 +50,7 @@ in
     meta = {
       description = "Simple, well tested, and robust set of predefined commands for use by Python users";
       homepage = "https://epics.anl.gov/tech-talk/2022/msg01072.php";
+      mainProgram = "phoebus-scan-server";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
       inherit (jdk.meta) platforms;

--- a/pkgs/epnix/tools/procServ/default.nix
+++ b/pkgs/epnix/tools/procServ/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Wrapper to start arbitrary interactive commands in the background, with telnet or Unix domain socket access to stdin/stdout";
     homepage = "https://github.com/ralphlange/procServ";
+    mainProgram = "procServ";
     license = lib.licenses.gpl3Plus;
     maintainers = with epnixLib.maintainers; [minijackson];
   };


### PR DESCRIPTION
Makes things nicer overall. No need to `"${pkgs.epnix.procServ}/bin/procServ"` when you can just `lib.getExe pkgs.epnix.procServ`

Fixes #62 