### PR TITLE
github: run jobs in pull_request_target

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -3,8 +3,8 @@ name: "Check EditorConfig"
 permissions: read-all
 
 on:
-  push:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   editorconfig:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -3,8 +3,8 @@ name: "Check Formatting"
 permissions: read-all
 
 on:
-  push:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   alejandra:


### PR DESCRIPTION
This enables jobs to run even for new contributors, because the definition of the job will be from the base branch of the PR, instead of the PR's latest commit.

So contributors can't modify the GitHub workflow and run whatever they want by just opening a PR.