### PR TITLE
Don't automatically enable elasticsearch

### DIFF
--- a/docs/nixos-services/user-guides/phoebus-alarm.rst
+++ b/docs/nixos-services/user-guides/phoebus-alarm.rst
@@ -52,7 +52,9 @@ and Kafka’s ``clusterId``:
 
      services.phoebus-alarm-logger.settings."bootstrap.servers" = kafkaListenSockAddr;
 
-     # Single-server Kafka setup
+     # Phoebus alarm needs Kafka.
+     # If not already enabled elsewhere in your configuration,
+     # the code below shows a single-server Kafka setup:
      services.apache-kafka = {
        enable = true;
        # Replace with a randomly generated uuid. You can get one by running:
@@ -89,6 +91,9 @@ and Kafka’s ``clusterId``:
      # Open kafka to the outside world
      networking.firewall.allowedTCPPorts = [9092];
 
+     # Phoebus alarm needs ElasticSearch.
+     # If not already enabled elsewhere in your configuration,
+     # Enable it with the code below:
      services.elasticsearch = {
        enable = true;
        package = pkgs.elasticsearch7;

--- a/docs/nixos-services/user-guides/phoebus-save-and-restore.rst
+++ b/docs/nixos-services/user-guides/phoebus-save-and-restore.rst
@@ -29,6 +29,14 @@ add this to your configuration:
        openFirewall = true;
      };
 
+     # Phoebus save-and-restore needs ElasticSearch.
+     # If not already enabled elsewhere in your configuration,
+     # Enable it with the code below:
+     services.elasticsearch = {
+       enable = true;
+       package = pkgs.elasticsearch7;
+     };
+
      # Elasticsearch, needed by Phoebus Save-and-restore, is not free software (SSPL | Elastic License).
      # To accept the license, add the code below:
      nixpkgs.config.allowUnfreePredicate = pkg:

--- a/docs/release-notes/2405.rst
+++ b/docs/release-notes/2405.rst
@@ -9,3 +9,11 @@ Breaking changes
 
 - The :nix:`config.epnix.outputs.mdbook` and :nix:`config.epnix.outputs.manpages` options
   from the IOC module options, previously deprecated, are now removed.
+
+- The :ref:`opt-services.phoebus-alarm-server.enable`,
+  :ref:`opt-services.phoebus-olog.enable`,
+  and :ref:`opt-services.phoebus-save-and-restore.enable` options
+  don't enable ElasticSearch automatically anymore.
+  See :doc:`../nixos-services/user-guides/phoebus-alarm`
+  and :doc:`../nixos-services/user-guides/phoebus-save-and-restore`
+  for how to enable it yourself on the same server.

--- a/nixos/modules/phoebus/olog.nix
+++ b/nixos/modules/phoebus/olog.nix
@@ -113,18 +113,8 @@ in {
         # TODO: systemd hardening. Currently level 8.2 EXPOSED
       };
     };
-
-    services.elasticsearch = {
-      enable = true;
-      # Should be kept in sync with the phoebus-alarm-logger and phoebus-save-and-restore services
-      package = pkgs.elasticsearch7;
-    };
     services.mongodb.enable = true;
   };
 
-  meta = {
-    maintainers = with epnixLib.maintainers; [minijackson];
-    # TODO:
-    # doc = ./olog.md;
-  };
+  meta.maintainers = with epnixLib.maintainers; [minijackson];
 }

--- a/nixos/modules/phoebus/save-and-restore.nix
+++ b/nixos/modules/phoebus/save-and-restore.nix
@@ -8,8 +8,6 @@
   cfg = config.services.phoebus-save-and-restore;
   settingsFormat = pkgs.formats.javaProperties {};
   configFile = settingsFormat.generate "phoebus-save-and-restore.properties" cfg.settings;
-
-  localElasticsearch = cfg.settings."elasticsearch.network.host" == "localhost";
 in {
   options.services.phoebus-save-and-restore = {
     enable = lib.mkEnableOption ''
@@ -81,7 +79,7 @@ in {
       description = "Phoebus Save-and-restore";
 
       wantedBy = ["multi-user.target"];
-      after = lib.mkIf localElasticsearch ["elasticsearch.service"];
+      after = ["elasticsearch.service"];
 
       serviceConfig = {
         ExecStart = "${lib.getExe pkgs.epnix.phoebus-save-and-restore} --spring.config.location=file://${configFile}";
@@ -138,12 +136,6 @@ in {
         # Disallowed system calls return EPERM instead of terminating the service
         SystemCallErrorNumber = "EPERM";
       };
-    };
-
-    services.elasticsearch = lib.mkIf localElasticsearch {
-      enable = true;
-      # Should be kept in sync with the phoebus-alarm-logger and phoebus-olog services
-      package = pkgs.elasticsearch7;
     };
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [

--- a/nixos/tests/phoebus/olog.nix
+++ b/nixos/tests/phoebus/olog.nix
@@ -7,10 +7,15 @@
   meta.maintainers = with epnixLib.maintainers; [minijackson];
 
   nodes = {
-    server = {
+    server = {pkgs, ...}: {
       services.phoebus-olog = {
         enable = true;
         settings."demo_auth.enabled" = true;
+      };
+
+      services.elasticsearch = {
+        enable = true;
+        package = pkgs.elasticsearch7;
       };
 
       nixpkgs.config.allowUnfreePredicate = pkg:

--- a/nixos/tests/phoebus/save-and-restore.nix
+++ b/nixos/tests/phoebus/save-and-restore.nix
@@ -7,10 +7,15 @@
   meta.maintainers = with epnixLib.maintainers; [minijackson];
 
   nodes = {
-    server = {
+    server = {pkgs, ...}: {
       services.phoebus-save-and-restore = {
         enable = true;
         openFirewall = true;
+      };
+
+      services.elasticsearch = {
+        enable = true;
+        package = pkgs.elasticsearch7;
       };
 
       nixpkgs.config.allowUnfreePredicate = pkg:


### PR DESCRIPTION
For Phoebus Olog, and Phoebus save-and-restore

See https://github.com/epics-extensions/EPNix/issues/75, https://github.com/epics-extensions/EPNix/issues/54, follow-up of https://github.com/epics-extensions/EPNix/pull/60

Specify in documentation that enabling ElasticSearch needs to be done
only once.