### PR TITLE
nixos/phoebus-alarm-logger: forward configuration to SpringBoot

### DIFF
--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -137,8 +137,16 @@ in {
 
       wantedBy = ["multi-user.target"];
 
-      # Weirdly not "phoebus.user"
-      environment.JAVA_OPTS = "-Djava.util.prefs.userRoot=/var/lib/phoebus-alarm-logger";
+      environment = {
+        # Weirdly not "phoebus.user"
+        JAVA_OPTS = "-Djava.util.prefs.userRoot=/var/lib/phoebus-alarm-logger";
+
+        # Our config file is both the config file for phoebus-alarm-logger,
+        # and for SpringBoot.
+        # The '-properties' command-line argument is only for phoebus-alarm-logger,
+        # *not* SpringBoot.
+        SPRING_CONFIG_IMPORT = configFile;
+      };
 
       serviceConfig = {
         ExecStart = let

--- a/nixos/tests/phoebus/alarm.nix
+++ b/nixos/tests/phoebus/alarm.nix
@@ -26,7 +26,6 @@
     };
 
     server = {
-      config,
       lib,
       pkgs,
       ...
@@ -45,7 +44,10 @@
         };
       };
 
-      services.phoebus-alarm-logger.settings."bootstrap.servers" = kafkaListenSockAddr;
+      services.phoebus-alarm-logger.settings = {
+        "bootstrap.servers" = kafkaListenSockAddr;
+        "server.port" = 8082;
+      };
 
       services.apache-kafka = {
         enable = true;

--- a/nixos/tests/phoebus/alarm.py
+++ b/nixos/tests/phoebus/alarm.py
@@ -13,7 +13,7 @@ def wait_for_boot():
         server.wait_for_unit("phoebus-alarm-logger.service")
         server.wait_for_open_port(9092, "192.168.1.3")
         server.wait_for_open_port(9200)
-        server.wait_for_open_port(8080)
+        server.wait_for_open_port(8082)
 
         ioc.wait_for_unit("ioc.service")
 
@@ -47,7 +47,7 @@ def get_alarm() -> dict[str, Any]:
 
 
 def get_logger(uri: str):
-    result_s = client.succeed(f"curl 'http://server:8080{uri}'")
+    result_s = client.succeed(f"curl 'http://server:8082{uri}'")
     return json.loads(result_s)
 
 


### PR DESCRIPTION
phoebus-alarm-logger does not forward the given configuration to SpringBoot, so we use an environment variable to forward it ourselves.

this caused options like "server.port" to be ignored, since they are SpringBoto specific.

Use the "server.port" option in the test to test regressions.

fixes #56