### PR TITLE
ChannelFinder

### DIFF
--- a/docs/ioc/user-guides/index.rst
+++ b/docs/ioc/user-guides/index.rst
@@ -13,6 +13,7 @@ User guides
    ./private-repo-setup.rst
    ./flake-registry.rst
    ./developing-modules.rst
+   ./reccaster.rst
    ./mrf-devices.rst
    ./testing/index.rst
 

--- a/docs/ioc/user-guides/reccaster.rst
+++ b/docs/ioc/user-guides/reccaster.rst
@@ -1,0 +1,121 @@
+RecCaster configuration
+=======================
+
+RecCaster is an EPICS support module
+that sends PV names and IOC metadata to a "RecCeiver" server.
+This setup is often used to send such metadata to a ChannelFinder database.
+
+.. seealso::
+
+   If you want to set up a RecCeiver and ChannelFinder server,
+   examine the guide
+   :doc:`../../nixos-services/user-guides/channel-finder`.
+
+Configuration
+-------------
+
+To configure RecCaster,
+first add it to your build environment:
+
+.. code-block:: diff
+   :caption: :file:`flake.nix`
+
+            # Add your support modules here:
+            # ---
+   -        #support.modules = with pkgs.epnix.support; [ StreamDevice mySupportModule ];
+   +        support.modules = with pkgs.epnix.support; [ reccaster ];
+
+Make sure your app depends on the RecCaster library and DBD file:
+
+.. code-block:: make
+   :caption: :file:`{example}App/src/Makefile`
+
+   # Replace "example" by the name of your application
+   example_DBD += reccaster.dbd
+   example_LIBS += reccaster
+
+And load the RecCaster database:
+
+.. code-block:: csh
+   :caption: :file:`iocBoot/ioc{Example}/st.cmd`
+
+   ## Load RecCaster records
+   ## Optional but useful for checking the synchronization state
+   ## Make sure to choose your prefix by setting the 'P' macro
+   dbLoadRecords("${RECCASTER}/db/reccaster.db", "P=YOUR-PV-PREFIX:")
+
+This configuration is enough to start the RecCaster client.
+
+.. note::
+
+   RecCaster doesn't need the address of the RecCeiver server.
+   The RecCeiver server scans for available IOCs on the network.
+
+Firewall
+--------
+
+To accept connection from the RecCeiver service,
+the firewall needs to allow the UDP announcert port,
+which by default is 5049.
+
+If your IOC is a NixOS machine,
+you can open the firewall with this NixOS configuration:
+
+.. code-block:: nix
+   :caption: Opening the firewall for RecCeiver
+
+   networking.firewall.allowedUDPPorts = [5049];
+
+Checking synchronization status
+-------------------------------
+
+To check the RecCaster status of your IOC,
+you can run:
+
+.. code-block:: bash
+
+   # Replace 'YOUR-PV-PREFIX:' with your PV prefix
+   caget "YOUR-PV-PREFIX:Msg-I"
+   caget "YOUR-PV-PREFIX:State-Sts"
+
+Adding IOC metadata
+-------------------
+
+You can choose to send more information to the RecCeiver server.
+
+If you want to add metadata about the global IOC,
+set it as environment variable
+and expose it using the ``addReccasterEnvVars`` function.
+For example:
+
+.. code-block:: csh
+   :caption: :file:`iocBoot/ioc{Example}/st.cmd`
+
+   epicsEnvSet("CONTACT", "mycontact")
+   addReccasterEnvVars("CONTACT")
+
+Make sure RecCeveiver forward those variables to ChannelFinder.
+See the RecCeiver guide's :ref:`recceiver-custom-metadata`.
+
+For more information about what information RecCaster sends to the server,
+examine the `RecSync README`_.
+
+.. tip::
+
+   RecCaster automatically sends some environment variables to RecCeiver,
+   without needing to call ``addReccasterEnvVars``,
+   for example:
+
+   - PWD
+   - EPICS_VERSION
+   - EPICS_HOST_ARCH
+   - IOCNAME
+   - HOSTNAME
+   - ENGINEER
+   - LOCATION
+
+   But those variables aren't automatically forwarded to ChannelFinder.
+   For how to forward them to ChannelFinder,
+   examine the RecCeiver guide's :ref:`recceiver-custom-metadata`.
+
+.. _RecSync README: https://github.com/ChannelFinder/recsync?tab=readme-ov-file#information-uploaded

--- a/docs/nixos-services/user-guides/channel-finder.rst
+++ b/docs/nixos-services/user-guides/channel-finder.rst
@@ -1,0 +1,334 @@
+ChannelFinder service setup
+===========================
+
+ChannelFinder is a directory service which enables searching for PV names,
+called *channels names*,
+and associated metadata.
+
+A ChannelFinder server is usually combined with a "RecCaster" module in the IOC,
+that sends the metadata,
+and a "RecCeiver" server
+that scans and retrieves the metadata from "RecCaster."
+
+For more information on the ChannelFinder architecture,
+see the official `ChannelFinder introduction`_.
+
+.. _ChannelFinder introduction: https://channelfinder.readthedocs.io/en/latest/overview.html
+
+.. include:: ./pre-requisites.rst
+
+ChannelFinder service
+---------------------
+
+To enable the ChannelFinder service,
+use :ref:`opt-services.channel-finder.enable` and related options.
+You will also need to enable ElasticSearch.
+
+For example:
+
+.. code-block:: nix
+   :caption: :file:`channel-finder.nix` --- ChannelFinder configuration example
+
+   {lib, pkgs, ...}: {
+     services.channel-finder = {
+       enable = true;
+       openFirewall = true;
+       settings = {
+
+         # Choose your authentication type (see below for explanations)
+         # ---
+         #"demo_auth.enabled" = true;
+         #"ldap.enabled" = true;
+
+         "server.port" = 8444;
+         "server.http.port" = 8082;
+       };
+     };
+
+     # Install Elasticsearch,
+     # because it's a ChannelFinder service dependency
+     services.elasticsearch = {
+       enable = true;
+       package = pkgs.elasticsearch7;
+     };
+
+     # Elasticsearch, needed by ChannelFinder, is not free software (SSPL | Elastic License).
+     # To accept the license, add the code below:
+     nixpkgs.config.allowUnfreePredicate = pkg:
+       builtins.elem (lib.getName pkg) [
+         "elasticsearch"
+       ];
+   }
+
+This configuration starts the ChannelFinder service on port 8082.
+You can open your browser at http://localhost:8082/ to see the ChannelFinder admin page.
+
+For more settings,
+examine the `ChannelFinder configuration`_ reference
+and the :ref:`opt-services.channel-finder.settings` option.
+
+.. _ChannelFinder configuration: https://channelfinder.readthedocs.io/en/latest/config.html
+
+Authentication
+^^^^^^^^^^^^^^
+
+ChannelFinder supports different types of authentication backends:
+
+Demo authentication
+   *Not recommended for production servers*.
+   Users,
+   their roles,
+   and passwords
+   are specified in the configuration file,
+   in plain text.
+
+External LDAP server
+   The ChannelFinder service connects to an external LDAP server,
+   and uses it for authentication and role assignment.
+
+   .. note::
+      Configuring an fully-featured LDAP server is out of scope for this guide,
+      but the ChannelFinder service can connect to another service's embedded LDAP server.
+
+      For example,
+      ChannelFinder could connect to a Phoebus Olog's embedded LDAP server configured beforehand.
+
+Demo authentication
+~~~~~~~~~~~~~~~~~~~
+
+.. caution::
+
+   This authentication type is not recommended for production servers.
+
+Users,
+roles,
+and passwords
+are stored as comma-separated list in the configuration.
+
+For example:
+
+.. code-block:: nix
+   :caption: :file:`channel-finder.nix` --- demo authentication example
+
+   services.channel-finder = {
+     settings = {
+       "demo_auth.enabled" = true;
+       "demo_auth.users" = "admin,operator,expert";
+       "demo_auth.pwd" = "adminPass,operatorPass,expertPass";
+       # Multiple roles can be given by separating them with ':'
+       "demo_auth.roles" = "ADMIN:EXPERT,USER,USER:EXPERT";
+     };
+   };
+
+External LDAP server
+~~~~~~~~~~~~~~~~~~~~
+
+This section assumes you already have a configured LDAP server.
+This configured LDAP server can be an embedded LDAP server of another service.
+
+If you want to use your company's LDAP server,
+contact your IT team for the LDAP configuration:
+
+- URL,
+- base DN,
+- user DN pattern,
+- search base,
+- and search path.
+
+Here is an example configuration:
+
+.. code-block:: nix
+   :caption: :file:`channel-finder.nix` --- external LDAP authentication example
+
+   services.channel-finder = {
+     settings = {
+       "ldap.enabled" = true;
+       "ldap.urls" = "ldaps://auth.mycompany.com/dc=mycompany,dc=com";
+       "ldap.user.dn.pattern" = "uid={0},ou=People,dc=mycompany,dc=com";
+       "ldap.groups.search.base" = "ou=Group,dc=mycompany,dc=com";
+       "ldap.groups.search.pattern" = "(memberUid= {1})";
+     };
+   };
+
+RecCeiver
+---------
+
+The RecCeiver service scans for IOCs in the network,
+and fetches the list of PV names and other metadata.
+You can configure it to put this information into the ChannelFinder service.
+
+Use the ``channelfinderapi.DEFAULT`` setting for configuring the connection to the ChannelFinder service,
+and use the ``settings`` option for configuring all other settings.
+
+For a list of available ``settings``,
+examine the `RecCeiver demo.conf`_ file.
+
+Also examine the :ref:`opt-services.recceiver.channelfinderapi`
+and :ref:`opt-services.recceiver.settings` options.
+
+TODO: explain which cf role is needed
+
+For example:
+
+.. code-block:: nix
+   :caption: :file:`channel-finder.nix` --- RecCeiver configuration example
+   :name: recceiver-configuration-example
+
+   {lib, pkgs, ...}: {
+     # Other previous options...
+
+     services.recceiver = {
+       enable = true;
+
+       channelfinderapi.DEFAULT = {
+         username = "admin";
+         password = "adminPass";
+       };
+
+       settings = {
+         recceiver = {
+           # Necessary if you want a firewall,
+           # which is enabled by default in NixOS.
+           bind = "0.0.0.0:5050";
+
+           # When receiving metadata,
+           # print it on the command-line (show),
+           # and send it to ChannelFinder (cf).
+           procs = ["show" "cf"];
+         };
+         cf = {
+           # PV metadata to send to ChannelFinder
+           alias = "on";
+           recordDesc = "on";
+           recordType = "on";
+         };
+       };
+     };
+
+     networking.firewall.allowedTCPPorts = [5050];
+   }
+
+.. _RecCeiver demo.conf: https://github.com/ChannelFinder/recsync/blob/1.6/server/demo.conf
+
+.. _recceiver-firewall:
+
+Firewall
+^^^^^^^^
+
+If ``settings.bind`` is unset,
+RecCeiver listens on a random port,
+which makes it difficult to open the firewall.
+
+To open the firewall,
+make sure to set the bind address to a fixed port,
+and open it in the firewall as TCP,
+as shown in the :ref:`recceiver-configuration-example`.
+
+On the IOC side,
+the firewall needs to allow the UDP announcer port,
+which by default is 5049.
+
+If your IOC is a NixOS machine,
+you can open the firewall with this configuration:
+
+.. code-block:: nix
+   :caption: Opening the IOC's firewall for RecCaster
+
+   networking.firewall.allowedUDPPorts = [5049];
+
+Setting the address list
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want to scan a specific network,
+or if you want to change the port number used for scanning,
+you can use the ``settings.recceiver.addrlist`` option.
+
+.. warning::
+
+   If you change the port,
+   make sure to also change it in the IOC firewall rules.
+
+   See :ref:`recceiver-firewall`.
+
+.. code-block:: nix
+   :caption: :file:`channel-finder.nix` --- changing the RecCeiver address list
+
+   {lib, pkgs, ...}: {
+     # ...
+
+     services.recceiver = {
+       # ...
+       settings = {
+         recceiver = {
+           # ...
+
+           # If you change the port,
+           # make sure to also change it in the IOC firewall rules
+           addrlist = ["192.168.1.255:5049"];
+         };
+         # ...
+       };
+     };
+
+     # ...
+   }
+
+.. _recceiver-custom-metadata:
+
+Custom metadata
+^^^^^^^^^^^^^^^
+
+To add custom metadata variable to the ChannelFinder service,
+use the ``settings.cf.environment_vars`` option,
+for example:
+
+.. code-block:: nix
+   :caption: :file:`channel-finder.nix` --- adding custom metadata to ChannelFinder
+
+   {lib, pkgs, ...}: {
+     # ...
+
+     services.recceiver = {
+       # ...
+       settings = {
+         # ...
+         cf = {
+           # ...
+           environment_vars = {
+             # Follows the pattern:
+             # IOC_VARIABLE = "ChannelFinderProperty";
+             CONTACT = "Concact";
+             EPICS_BASE = "EpicsBase";
+             EPICS_VERSION = "EpicsVersion";
+             PWD = "WorkingDirectory";
+           };
+         };
+       };
+     };
+   };
+
+External ChannelFinder server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your ChannelFinder server is located on another machine,
+use the ``channelfinderapi.DEFAULT.BaseURL`` option:
+
+.. code-block:: nix
+   :caption: :file:`channel-finder.nix` --- specifying an external ChannelFinder server
+
+     services.recceiver = {
+       # ...
+
+       channelfinderapi.DEFAULT = {
+         BaseURL = "http://192.168.1.42:8082/ChannelFinder";
+         # ...
+       };
+
+       # ...
+     };
+
+RecCaster
+---------
+
+To configure RecCaster in your IOCs,
+examine the guide :doc:`../../ioc/user-guides/reccaster`.

--- a/docs/nixos-services/user-guides/index.rst
+++ b/docs/nixos-services/user-guides/index.rst
@@ -11,5 +11,6 @@ User guides
    :maxdepth: 1
 
    ./ca-gateway.rst
+   ./channel-finder.rst
    ./phoebus-alarm.rst
    ./phoebus-save-and-restore.rst

--- a/nixos/module-list.nix
+++ b/nixos/module-list.nix
@@ -1,6 +1,7 @@
 [
   ./modules/archiver-appliance.nix
   ./modules/ca-gateway.nix
+  ./modules/channel-finder/recceiver.nix
   ./modules/channel-finder/service.nix
   ./modules/phoebus/alarm-logger.nix
   ./modules/phoebus/alarm-server.nix

--- a/nixos/module-list.nix
+++ b/nixos/module-list.nix
@@ -1,6 +1,7 @@
 [
   ./modules/archiver-appliance.nix
   ./modules/ca-gateway.nix
+  ./modules/channel-finder/service.nix
   ./modules/phoebus/alarm-logger.nix
   ./modules/phoebus/alarm-server.nix
   ./modules/phoebus/olog.nix

--- a/nixos/modules/channel-finder/recceiver.nix
+++ b/nixos/modules/channel-finder/recceiver.nix
@@ -1,0 +1,215 @@
+{
+  config,
+  epnixLib,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.recceiver;
+
+  pkg = pkgs.python3Packages.recceiver;
+  python = pkgs.python3.withPackages (
+    ps: [
+      ps.recceiver
+      ps.twisted
+    ]
+  );
+
+  settingsFormat = pkgs.formats.ini {};
+  configFile = settingsFormat.generate "recceiver.conf" cfg.settings;
+  channelfinderapiConfFile = settingsFormat.generate "channelfinderapi.conf" cfg.channelfinderapi;
+in {
+  options.services.recceiver = {
+    enable = lib.mkEnableOption "the RecCeiver service";
+
+    channelfinderapi = lib.mkOption {
+      description = ''
+        Configuration for the ChannelFinder client.
+
+        See upstream documentation for all supported options:
+        <https://github.com/ChannelFinder/pyCFClient?tab=readme-ov-file#configuration>
+      '';
+      default = {};
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+        options.DEFAULT = {
+          BaseURL = lib.mkOption {
+            type = lib.types.str;
+            default = "http://localhost:8080/ChannelFinder";
+            description = "URL of the remote ChannelFinder server.";
+          };
+
+          username = lib.mkOption {
+            type = with lib.types; nullOr str;
+            default = null;
+            description = "Username for authentication.";
+          };
+
+          password = lib.mkOption {
+            type = with lib.types; nullOr str;
+            default = null;
+            description = "Password for authentication.";
+          };
+        };
+      };
+    };
+
+    settings = lib.mkOption {
+      description = ''
+        Configuration for the RecCeiver service.
+
+        See upstream documentation for all supported options:
+        <https://github.com/ChannelFinder/recsync/blob/${pkg.version}/server/demo.conf>
+      '';
+      default = {};
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          recceiver = {
+            bind = lib.mkOption {
+              type = lib.types.str;
+              default = "0.0.0.0:0";
+              description = ''
+                Listen for TCP connections on this interface and port.
+
+                Port also used as source for UDP broadcasts
+
+                Default uses wildcard address and a random port.
+              '';
+            };
+
+            addrlist = lib.mkOption {
+              type = with lib.types; listOf str;
+              default = ["255.255.255.255:5049"];
+              apply = lib.concatStringsSep ",";
+              description = ''
+                Listen for TCP connections on this interface and port.
+
+                Port also used as source for UDP broadcasts
+
+                Default uses wildcard address and a random port.
+              '';
+            };
+
+            procs = lib.mkOption {
+              type = with lib.types; listOf str;
+              default = ["show"];
+              example = ["show" "cf"];
+              apply = lib.concatStringsSep ",";
+              description = ''
+                Processing chain, sequence of plugin names.
+
+                Plugin names may be followed by an instance name (eg. `db:arbitrary`)
+                which allows for more than one instance of a plugin with different
+                configuration.
+
+                Default plugins:
+
+                `show`
+                : Prints information to daemon log
+
+                `db`
+                : Stores in sqlite3 database
+
+                `cf`
+                : Stores in a ChannelFinder server
+              '';
+            };
+          };
+
+          cf = {
+            environment_vars = lib.mkOption {
+              type = with lib.types; attrsOf str;
+              default = {};
+              example = {
+                ENGINEER = "Engineer";
+                EPICS_BASE = "EpicsVersion";
+                PWD = "WorkingDirectory";
+              };
+              apply = val: lib.concatStringsSep "," (lib.mapAttrsToList (k: v: "${k}:${v}") val);
+              description = ''
+                Attribute set of `VARIABLE = "PropertyName";`
+
+                Specifies which environment `VARIABLE`s to pass on to the ChannelFinder server,
+                and defining the corresponding `PropertyName`.
+              '';
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.recceiver = {
+      inherit (pkg.meta) description;
+
+      wantedBy = ["multi-user.target"];
+      after = ["channel-finder.service"];
+
+      preStart = ''
+        ln -sfn "${channelfinderapiConfFile}" "$STATE_DIRECTORY/channelfinderapi.conf"
+      '';
+
+      serviceConfig = {
+        ExecStart = "${python}/bin/twistd --nodaemon --no_save --reactor=poll --pidfile= --logfile=- recceiver --config=${configFile}";
+        DynamicUser = true;
+        Restart = "on-failure";
+        StateDirectory = "recceiver";
+
+        # channelfinderapi.conf needs to be in the working directory
+        WorkingDirectory = "/var/lib/recceiver";
+
+        # Security options:
+        # ---
+
+        RestrictAddressFamilies = ["AF_INET" "AF_INET6"];
+        # Service may not create new namespaces
+        RestrictNamespaces = true;
+
+        # Service does not have access to other users
+        PrivateUsers = true;
+        # Service has no access to hardware devices
+        PrivateDevices = true;
+
+        # Service cannot write to the hardware clock or system clock
+        ProtectClock = true;
+        # Service cannot modify the control group file system
+        ProtectControlGroups = true;
+        # Service has no access to home directories
+        ProtectHome = true;
+        # Service cannot change system host/domainname
+        ProtectHostname = true;
+        # Service cannot read from or write to the kernel log ring buffer
+        ProtectKernelLogs = true;
+        # Service cannot load or read kernel modules
+        ProtectKernelModules = true;
+        # Service cannot alter kernel tunables (/proc/sys, …)
+        ProtectKernelTunables = true;
+        # Service has restricted access to process tree (/proc hidepid=)
+        ProtectProc = "invisible";
+
+        # Service may not acquire new capabilities
+        CapabilityBoundingSet = "";
+        # Service cannot change ABI personality
+        LockPersonality = true;
+        # Service has no access to non-process /proc files (/proc subset=)
+        ProcSubset = "pid";
+        # Service may execute system calls only with native ABI
+        SystemCallArchitectures = "native";
+        # Access write directories
+        UMask = "0077";
+        # Service may not create writable executable memory mappings
+        MemoryDenyWriteExecute = true;
+
+        # Service can only use a reasonable set of system calls,
+        # used by common system services
+        SystemCallFilter = ["@system-service"];
+        # Disallowed system calls return EPERM instead of terminating the service
+        SystemCallErrorNumber = "EPERM";
+      };
+    };
+  };
+
+  meta.maintainers = with epnixLib.maintainers; [minijackson];
+}

--- a/nixos/modules/channel-finder/service.nix
+++ b/nixos/modules/channel-finder/service.nix
@@ -1,0 +1,216 @@
+{
+  config,
+  epnixLib,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.channel-finder;
+  settingsFormat = pkgs.formats.javaProperties {};
+  configFile = settingsFormat.generate "channel-finder.properties" cfg.settings;
+in {
+  options.services.channel-finder = {
+    enable = lib.mkEnableOption "the ChannelFinder service";
+
+    openFirewall = lib.mkOption {
+      description = ''
+        Open the firewall for the ChannelFinder service.
+
+        ```{warning}
+        This opens the firewall on all network interfaces.
+        ```
+
+        This option opens firewall for the HTTP/HTTPS API,
+        and pvAccess server.
+      '';
+      type = lib.types.bool;
+      default = false;
+    };
+
+    settings = lib.mkOption {
+      description = ''
+        Configuration for the ChannelFinder service.
+
+        These options will be put into a `.properties` file.
+
+        Note that options containing a "." must be quoted.
+
+        See upstream documentation for all supported options:
+        <https://channelfinder.readthedocs.io/en/latest/config.html#application-properties>
+      '';
+      default = {};
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          "server.port" = lib.mkOption {
+            type = lib.types.port;
+            default = 8443;
+            # TODO: Weirdness of the javaProperties format?
+            # It says it supports integers and booleans, but during the build
+            # only accepts strings?
+            apply = toString;
+            description = "The HTTPS server port for the ChannelFinder service";
+          };
+
+          "server.http.enable" = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            apply = lib.boolToString;
+            description = "Enable unsecure HTTP";
+          };
+
+          "server.http.port" = lib.mkOption {
+            type = lib.types.port;
+            default = 8080;
+            apply = toString;
+            description = "The HTTP server port for the ChannelFinder service";
+          };
+
+          "elasticsearch.host_urls" = lib.mkOption {
+            type = with lib.types; listOf str;
+            default = ["http://localhost:9200"];
+            description = ''
+              List of URLs for the Elasticsearch hosts.
+
+              All hosts listed here must belong to the same Elasticsearch cluster.
+            '';
+            apply = lib.concatStringsSep ",";
+          };
+
+          "elasticsearch.create.indices" = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              List of URLs for the Elasticsearch hosts.
+
+              All hosts listed here must belong to the same Elasticsearch cluster.
+            '';
+            apply = lib.boolToString;
+          };
+
+          "demo_auth.enabled" = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            apply = lib.boolToString;
+            description = ''
+              Enable the demo authentication.
+
+              ChannelFinder will provide two users:
+
+              - `admin:adminPass`
+              - `user:userPass`
+            '';
+          };
+
+          "ldap.enabled" = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            apply = lib.boolToString;
+            description = ''
+              Enable authenticating to an external LDAP server.
+            '';
+          };
+
+          "embedded_ldap.enabled" = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            apply = lib.boolToString;
+            description = ''
+              Enable the embedded LDAP authentication.
+            '';
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = with cfg;
+          settings."ldap.enabled"
+          == "true"
+          || settings."embedded_ldap.enabled" == "true"
+          || settings."demo_auth.enabled" == "true";
+        message = "One type of authentication for Phoebus Olog must be provided";
+      }
+    ];
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [
+        (lib.toInt cfg.settings."server.port")
+        (lib.mkIf (cfg.settings."server.http.enable" == "true") (
+          lib.toInt cfg.settings."server.http.port" or "8080"
+        ))
+
+        # pvAccess
+        5075
+      ];
+      allowedUDPPorts = [5076];
+    };
+
+    systemd.services.channel-finder = {
+      inherit (pkgs.epnix.channel-finder-service.meta) description;
+
+      wantedBy = ["multi-user.target"];
+      after = ["elasticsearch.service"];
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe pkgs.epnix.channel-finder-service} --spring.config.location=file://${configFile}";
+        DynamicUser = true;
+        Restart = "on-failure";
+
+        # Security options:
+        # ---
+
+        RestrictAddressFamilies = ["AF_INET" "AF_INET6"];
+        # Service may not create new namespaces
+        RestrictNamespaces = true;
+
+        # Service does not have access to other users
+        PrivateUsers = true;
+        # Service has no access to hardware devices
+        PrivateDevices = true;
+
+        # Service cannot write to the hardware clock or system clock
+        ProtectClock = true;
+        # Service cannot modify the control group file system
+        ProtectControlGroups = true;
+        # Service has no access to home directories
+        ProtectHome = true;
+        # Service cannot change system host/domainname
+        ProtectHostname = true;
+        # Service cannot read from or write to the kernel log ring buffer
+        ProtectKernelLogs = true;
+        # Service cannot load or read kernel modules
+        ProtectKernelModules = true;
+        # Service cannot alter kernel tunables (/proc/sys, …)
+        ProtectKernelTunables = true;
+        # Service has restricted access to process tree (/proc hidepid=)
+        ProtectProc = "invisible";
+
+        # Service may not acquire new capabilities
+        CapabilityBoundingSet = "";
+        # Service cannot change ABI personality
+        LockPersonality = true;
+        # Service has no access to non-process /proc files (/proc subset=)
+        ProcSubset = "pid";
+        # Service may execute system calls only with native ABI
+        SystemCallArchitectures = "native";
+        # Access write directories
+        UMask = "0077";
+        # Service may create writable executable memory mappings
+        # This option isn't set due to the JVM marking some memory pages as executable
+        #MemoryDenyWriteExecute = true;
+
+        # Service can only use a reasonable set of system calls,
+        # used by common system services
+        SystemCallFilter = ["@system-service"];
+        # Disallowed system calls return EPERM instead of terminating the service
+        SystemCallErrorNumber = "EPERM";
+      };
+    };
+  };
+
+  meta.maintainers = with epnixLib.maintainers; [minijackson];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -17,6 +17,7 @@
 in {
   archiver-appliance = handleTest ./archiver-appliance {};
   ca-gateway = handleTest ./ca-gateway.nix {};
+  channel-finder = handleTest ./channel-finder {};
   phoebus-alarm = handleTest ./phoebus/alarm.nix {};
   phoebus-olog = handleTest ./phoebus/olog.nix {};
   phoebus-save-and-restore = handleTest ./phoebus/save-and-restore.nix {};

--- a/nixos/tests/channel-finder/default.nix
+++ b/nixos/tests/channel-finder/default.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  epnixLib,
+  pkgs,
+  ...
+}: let
+  inherit (pkgs.stdenv.hostPlatform) system;
+
+  iocConfig = epnixLib.evalEpnixModules {
+    nixpkgsConfig.system = system;
+    epnixConfig.imports = [./ioc.nix];
+  };
+
+  iocService = iocConfig.config.epnix.nixos.services.ioc.config;
+in {
+  name = "channel-finder-simple-check";
+  meta.maintainers = with epnixLib.maintainers; [minijackson];
+
+  nodes = let
+    serverPort = 5050;
+    announcerPort = 5049;
+  in {
+    server = {pkgs, ...}: {
+      environment.systemPackages = [pkgs.epnix.epics-base];
+
+      services.recceiver = {
+        enable = lib.mkDefault true;
+
+        channelfinderapi.DEFAULT = {
+          BaseURL = "http://localhost:8082/ChannelFinder";
+          username = "admin";
+          password = "adminPass";
+        };
+
+        settings = {
+          recceiver = {
+            loglevel = "DEBUG";
+            bind = "0.0.0.0:${toString serverPort}";
+            addrlist = ["192.168.1.255:${toString announcerPort}"];
+            procs = ["show" "cf"];
+          };
+          cf = {
+            alias = "on";
+            recordDesc = "on";
+            recordType = "on";
+            environment_vars = {
+              ENGINEER = "Engineer";
+              EPICS_BASE = "EpicsBase";
+              EPICS_VERSION = "EpicsVersion";
+              PWD = "WorkingDirectory";
+            };
+          };
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = [serverPort];
+
+      services.channel-finder = {
+        enable = true;
+        openFirewall = true;
+        settings = {
+          "demo_auth.enabled" = true;
+          "server.port" = 8444;
+          "server.http.port" = 8082;
+        };
+      };
+
+      services.elasticsearch = {
+        enable = true;
+        package = pkgs.elasticsearch7;
+      };
+
+      nixpkgs.config.allowUnfreePredicate = pkg:
+        builtins.elem (lib.getName pkg) [
+          # Elasticsearch can be used as an SSPL-licensed software, which is
+          # not open-source. But as we're using it run tests, not exposing
+          # any service, this should be fine.
+          "elasticsearch"
+        ];
+
+      # Else some applications might get killed by the OOM killer
+      virtualisation.memorySize = 2047;
+    };
+
+    client = {
+      environment.systemPackages = [pkgs.epnix.epics-base];
+      systemd.services.ioc = iocService;
+      networking.firewall.allowedUDPPorts = [announcerPort];
+    };
+  };
+
+  extraPythonPackages = p: [p.json5];
+  # Type checking on extra packages doesn't work yet
+  skipTypeCheck = true;
+
+  testScript = builtins.readFile ./test_script.py;
+}

--- a/nixos/tests/channel-finder/ioc.nix
+++ b/nixos/tests/channel-finder/ioc.nix
@@ -1,0 +1,13 @@
+{pkgs, ...}: {
+  epnix = {
+    meta.name = "channel-finder-test-ioc";
+    buildConfig.src = ./ioc;
+
+    support.modules = [pkgs.epnix.support.reccaster];
+
+    nixos.services.ioc = {
+      app = "simple";
+      ioc = "iocSimple";
+    };
+  };
+}

--- a/nixos/tests/channel-finder/ioc/.gitignore
+++ b/nixos/tests/channel-finder/ioc/.gitignore
@@ -1,0 +1,32 @@
+# Install directories
+/bin/
+/cfg/
+/db/
+/dbd/
+/html/
+/include/
+/lib/
+/templates/
+
+# Local configuration files
+/configure/*.local
+
+# iocBoot generated files
+/iocBoot/*ioc*/cdCommands
+/iocBoot/*ioc*/dllPath.bat
+/iocBoot/*ioc*/envPaths
+/iocBoot/*ioc*/relPaths.sh
+
+# iocsh
+.iocsh_history
+
+# Build directories
+O.*/
+
+# Common files created by other tools
+/QtC-*
+/.vscode/
+*.orig
+*.log
+.*.swp
+.DS_Store

--- a/nixos/tests/channel-finder/ioc/Makefile
+++ b/nixos/tests/channel-finder/ioc/Makefile
@@ -1,0 +1,31 @@
+# Makefile at top of application tree
+TOP = .
+include $(TOP)/configure/CONFIG
+
+# Directories to build, any order
+DIRS += configure
+DIRS += $(wildcard *Sup)
+DIRS += $(wildcard *App)
+DIRS += $(wildcard *Top)
+DIRS += $(wildcard iocBoot)
+
+# The build order is controlled by these dependency rules:
+
+# All dirs except configure depend on configure
+$(foreach dir, $(filter-out configure, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += configure))
+
+# Any *App dirs depend on all *Sup dirs
+$(foreach dir, $(filter %App, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup, $(DIRS))))
+
+# Any *Top dirs depend on all *Sup and *App dirs
+$(foreach dir, $(filter %Top, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup %App, $(DIRS))))
+
+# iocBoot depends on all *App dirs
+iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+
+# Add any additional dependency rules here:
+
+include $(TOP)/configure/RULES_TOP

--- a/nixos/tests/channel-finder/ioc/configure/CONFIG
+++ b/nixos/tests/channel-finder/ioc/configure/CONFIG
@@ -1,0 +1,45 @@
+# CONFIG - Load build configuration data
+#
+# Do not make changes to this file!
+
+# Allow user to override where the build rules come from
+RULES = $(EPICS_BASE)
+
+# RELEASE files point to other application tops
+include $(TOP)/configure/RELEASE
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+
+ifdef T_A
+  -include $(TOP)/configure/RELEASE.Common.$(T_A)
+  -include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+# Check EPICS_BASE is set properly
+ifneq (file,$(origin EPICS_BASE))
+  $(error EPICS_BASE must be set in a configure/RELEASE file)
+else
+  ifeq ($(wildcard $(EPICS_BASE)/configure/CONFIG_BASE),)
+    $(error EPICS_BASE does not point to an EPICS installation)
+  endif
+endif
+
+CONFIG = $(RULES)/configure
+include $(CONFIG)/CONFIG
+
+# Override the Base definition:
+INSTALL_LOCATION = $(TOP)
+
+# CONFIG_SITE files contain local build configuration settings
+include $(TOP)/configure/CONFIG_SITE
+
+# Host-arch specific settings
+-include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+
+ifdef T_A
+  # Target-arch specific settings
+ -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+
+  #  Host & target specific settings
+ -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/nixos/tests/channel-finder/ioc/configure/CONFIG_SITE
+++ b/nixos/tests/channel-finder/ioc/configure/CONFIG_SITE
@@ -1,0 +1,43 @@
+# CONFIG_SITE
+
+# Make any application-specific changes to the EPICS build
+#   configuration variables in this file.
+#
+# Host/target specific settings can be specified in files named
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+
+# CHECK_RELEASE controls the consistency checking of the support
+#   applications pointed to by the RELEASE* files.
+# Normally CHECK_RELEASE should be set to YES.
+# Set CHECK_RELEASE to NO to disable checking completely.
+# Set CHECK_RELEASE to WARN to perform consistency checking but
+#   continue building even if conflicts are found.
+CHECK_RELEASE = YES
+
+# Set this when you only want to compile this application
+#   for a subset of the cross-compiled target architectures
+#   that Base is built for.
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
+
+# To install files into a location other than $(TOP) define
+#   INSTALL_LOCATION here.
+#INSTALL_LOCATION=</absolute/path/to/install/top>
+
+# Set this when the IOC and build host use different paths
+#   to the install location. This may be needed to boot from
+#   a Microsoft FTP server say, or on some NFS configurations.
+#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
+
+# For application debugging purposes, override the HOST_OPT and/
+#   or CROSS_OPT settings from base/configure/CONFIG_SITE
+#HOST_OPT = NO
+#CROSS_OPT = NO
+
+# These allow developers to override the CONFIG_SITE variable
+# settings without having to modify the configure/CONFIG_SITE
+# file itself.
+-include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local
+

--- a/nixos/tests/channel-finder/ioc/configure/Makefile
+++ b/nixos/tests/channel-finder/ioc/configure/Makefile
@@ -1,0 +1,8 @@
+TOP=..
+
+include $(TOP)/configure/CONFIG
+
+TARGETS = $(CONFIG_TARGETS)
+CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
+
+include $(TOP)/configure/RULES

--- a/nixos/tests/channel-finder/ioc/configure/RELEASE
+++ b/nixos/tests/channel-finder/ioc/configure/RELEASE
@@ -1,0 +1,42 @@
+# RELEASE - Location of external support modules
+#
+# IF YOU CHANGE ANY PATHS in this file or make API changes to
+# any modules it refers to, you should do a "make rebuild" in
+# this application's top level directory.
+#
+# The EPICS build process does not check dependencies against
+# any files from outside the application, so it is safest to
+# rebuild it completely if any modules it depends on change.
+#
+# Host- or target-specific settings can be given in files named
+#  RELEASE.$(EPICS_HOST_ARCH).Common
+#  RELEASE.Common.$(T_A)
+#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+#
+# This file is parsed by both GNUmake and an EPICS Perl script,
+# so it may ONLY contain definititions of paths to other support
+# modules, variable definitions that are used in module paths,
+# and include statements that pull in other RELEASE files.
+# Variables may be used before their values have been set.
+# Build variables that are NOT used in paths should be set in
+# the CONFIG_SITE file.
+
+# Variables and paths to dependent modules:
+#MODULES = /path/to/modules
+#MYMODULE = $(MODULES)/my-module
+
+# If using the sequencer, point SNCSEQ at its top directory:
+#SNCSEQ = $(MODULES)/seq-ver
+
+# EPICS_BASE should appear last so earlier modules can override stuff:
+EPICS_BASE = /nix/store/bqlyj9i6g2a7jrwks24wj7bnk22agbs0-epics-base-7.0.8.1
+
+# Set RULES here if you want to use build rules from somewhere
+# other than EPICS_BASE:
+#RULES = $(MODULES)/build-rules
+
+# These lines allow developers to override these RELEASE settings
+# without having to modify this file directly.
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
+-include $(TOP)/configure/RELEASE.local

--- a/nixos/tests/channel-finder/ioc/configure/RULES
+++ b/nixos/tests/channel-finder/ioc/configure/RULES
@@ -1,0 +1,6 @@
+# RULES
+
+include $(CONFIG)/RULES
+
+# Library should be rebuilt because LIBOBJS may have changed.
+$(LIBNAME): ../Makefile

--- a/nixos/tests/channel-finder/ioc/configure/RULES.ioc
+++ b/nixos/tests/channel-finder/ioc/configure/RULES.ioc
@@ -1,0 +1,2 @@
+#RULES.ioc
+include $(CONFIG)/RULES.ioc

--- a/nixos/tests/channel-finder/ioc/configure/RULES_DIRS
+++ b/nixos/tests/channel-finder/ioc/configure/RULES_DIRS
@@ -1,0 +1,2 @@
+#RULES_DIRS
+include $(CONFIG)/RULES_DIRS

--- a/nixos/tests/channel-finder/ioc/configure/RULES_TOP
+++ b/nixos/tests/channel-finder/ioc/configure/RULES_TOP
@@ -1,0 +1,3 @@
+#RULES_TOP
+include $(CONFIG)/RULES_TOP
+

--- a/nixos/tests/channel-finder/ioc/iocBoot/Makefile
+++ b/nixos/tests/channel-finder/ioc/iocBoot/Makefile
@@ -1,0 +1,6 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS += $(wildcard *ioc*)
+DIRS += $(wildcard as*)
+include $(CONFIG)/RULES_DIRS
+

--- a/nixos/tests/channel-finder/ioc/iocBoot/iocSimple/Makefile
+++ b/nixos/tests/channel-finder/ioc/iocBoot/iocSimple/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths
+include $(TOP)/configure/RULES.ioc

--- a/nixos/tests/channel-finder/ioc/iocBoot/iocSimple/st.cmd
+++ b/nixos/tests/channel-finder/ioc/iocBoot/iocSimple/st.cmd
@@ -1,0 +1,27 @@
+#!../../bin/linux-x86_64/simple
+
+< envPaths
+
+## Register all support components
+dbLoadDatabase "${TOP}/dbd/simple.dbd"
+simple_registerRecordDeviceDriver(pdbbase)
+
+## Inspired by the reccaster demo IOC
+epicsEnvSet("IOCNAME", "myioc")
+epicsEnvSet("ENGINEER", "myself")
+epicsEnvSet("LOCATION", "myplace")
+
+epicsEnvSet("CONTACT", "mycontact")
+epicsEnvSet("BUILDING", "mybuilding")
+epicsEnvSet("SECTOR", "mysector")
+
+addReccasterEnvVars("CONTACT", "SECTOR")
+addReccasterEnvVars("BUILDING")
+
+## Load record instances
+dbLoadRecords("${TOP}/db/simple.db")
+
+## Load RecCaster records
+dbLoadRecords("${RECCASTER}/db/reccaster.db", "P=")
+
+iocInit()

--- a/nixos/tests/channel-finder/ioc/simpleApp/Db/Makefile
+++ b/nixos/tests/channel-finder/ioc/simpleApp/Db/Makefile
@@ -1,0 +1,18 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+DB += simple.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/nixos/tests/channel-finder/ioc/simpleApp/Db/simple.db
+++ b/nixos/tests/channel-finder/ioc/simpleApp/Db/simple.db
@@ -1,0 +1,13 @@
+record(ai, "RECORD1") {
+	alias("ALIAS_RECORD1")
+	info("test", "testing")
+}
+
+record(ai, "RECORD2") {
+	alias("ALIAS_RECORD2")
+	info("hello", "world")
+}
+
+record(ai, "RECORD3") {
+	field(DESC, "An empty ai record")
+}

--- a/nixos/tests/channel-finder/ioc/simpleApp/Makefile
+++ b/nixos/tests/channel-finder/ioc/simpleApp/Makefile
@@ -1,0 +1,14 @@
+# Makefile at top of application tree
+TOP = ..
+include $(TOP)/configure/CONFIG
+
+# Directories to be built, in any order.
+# You can replace these wildcards with an explicit list
+DIRS += $(wildcard src* *Src*)
+DIRS += $(wildcard db* *Db*)
+
+# If the build order matters, add dependency rules like this,
+# which specifies that xxxSrc must be built after src:
+#xxxSrc_DEPEND_DIRS += src
+
+include $(TOP)/configure/RULES_DIRS

--- a/nixos/tests/channel-finder/ioc/simpleApp/src/Makefile
+++ b/nixos/tests/channel-finder/ioc/simpleApp/src/Makefile
@@ -1,0 +1,39 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+#=============================
+# Build the IOC application
+
+PROD_IOC = simple
+# simple.dbd will be created and installed
+DBD += simple.dbd
+
+# simple.dbd will be made up from these files:
+simple_DBD += base.dbd
+simple_DBD += reccaster.dbd
+
+simple_LIBS += reccaster
+
+# simple_registerRecordDeviceDriver.cpp derives from simple.dbd
+simple_SRCS += simple_registerRecordDeviceDriver.cpp
+
+# Build the main IOC entry point on workstation OSs.
+simple_SRCS_DEFAULT += simpleMain.cpp
+simple_SRCS_vxWorks += -nil-
+
+# Add support from base/src/vxWorks if needed
+#simple_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
+
+# Finally link to the EPICS Base libraries
+simple_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+#===========================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/nixos/tests/channel-finder/ioc/simpleApp/src/simpleMain.cpp
+++ b/nixos/tests/channel-finder/ioc/simpleApp/src/simpleMain.cpp
@@ -1,0 +1,23 @@
+/* simpleMain.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/nixos/tests/channel-finder/test_script.py
+++ b/nixos/tests/channel-finder/test_script.py
@@ -1,0 +1,121 @@
+import json
+from typing import Any
+
+import json5
+
+start_all()
+
+server.wait_for_unit("channel-finder.service")
+server.wait_for_open_port(8082)
+server.wait_for_open_port(8444)
+
+client.wait_for_unit("multi-user.target")
+
+with subtest("ChannelFinder is listening on HTTP(S)"):
+    client.succeed("curl -sSfL http://server:8082/")
+    client.succeed("curl -sSfL -k https://server:8444/")
+
+
+def get(uri: str) -> Any:
+    result = client.succeed(f"curl -sSfL http://server:8082/ChannelFinder{uri}")
+    return json.loads(result)
+
+
+with subtest("ChannelFinder connected to ElasticSearch"):
+    status = get("/")
+    assert status["elastic"]["status"] == "Connected"
+
+server.wait_for_unit("recceiver.service")
+
+all_properties = {
+    "Engineer",
+    "EpicsBase",
+    "EpicsVersion",
+    "WorkingDirectory",
+    "alias",
+    "hostName",
+    "iocName",
+    "iocid",
+    "pvStatus",
+    "recceiverID",
+    "recordDesc",
+    "recordType",
+    "time",
+}
+
+all_channels = {
+    "ALIAS_RECORD1",
+    "ALIAS_RECORD2",
+    "Msg-I",
+    "RECORD1",
+    "RECORD2",
+    "RECORD3",
+    "State-Sts",
+}
+
+with subtest("RecCeiver sent all properties"):
+
+    def has_all_properties(_last: bool) -> bool:
+        properties = get("/resources/properties")
+        property_names = {prop["name"] for prop in properties}
+        return property_names == all_properties
+
+    retry(has_all_properties, timeout=30)
+
+with subtest("RecCeiver sent all channels"):
+
+    def property_is(props: list[Any], name: str, value: Any) -> bool:
+        for prop in props:
+            if prop["name"] == name:
+                return prop["value"] == value
+
+        # Property not found, fail
+        print(f"Property {name} not found")
+        return False
+
+    def has_all_channels(_last: bool) -> bool:
+        channels = get("/resources/channels")
+
+        channels = {chan["name"]: chan for chan in channels}
+
+        if channels.keys() != all_channels:
+            print("Not all channel names are here")
+            return False
+
+        for name, chan in channels.items():
+            properties = {prop["name"]: prop["value"] for prop in chan["properties"]}
+
+            assert properties["hostName"] == "client", f"wrong hostName for {name}"
+            assert properties["iocName"] == "myioc", f"wrong iocName for {name}"
+            assert properties["Engineer"] == "myself", f"wrong Engineer for {name}"
+
+            chan["properties"] = properties
+
+        # Description
+        assert (
+            channels["RECORD3"]["properties"]["recordDesc"] == "An empty ai record"
+        ), "wrong description for RECORD3"
+
+        # Aliases
+        assert (
+            channels["ALIAS_RECORD1"]["properties"]["alias"] == "RECORD1"
+        ), "wrong alias for RECORD1"
+        assert (
+            channels["ALIAS_RECORD2"]["properties"]["alias"] == "RECORD2"
+        ), "wrong alias for RECORD2"
+
+        return True
+
+    retry(has_all_channels, timeout=30)
+
+with subtest("Client considers itself synchronized"):
+    client.succeed("caget -t Msg-I | grep -qxF Synchronized")
+    client.succeed("caget -t State-Sts | grep -qxF Done")
+
+with subtest("ChannelFinder pvAccess server"):
+    server.wait_for_open_port(5075)
+    server.wait_until_succeeds("pvlist localhost", timeout=30)
+    data = json5.loads(server.succeed("pvcall -M json cfService:query"))
+
+    assert set(data["labels"]).issuperset(all_properties), "not all labels found"
+    assert set(data["value"]["channelName"]) == all_channels, "not all channels found"

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14,6 +14,7 @@ in
       ++ [
         (final: prev: {
           lewis = final.callPackage ./epnix/tools/lewis {};
+          channelfinder = final.callPackage ./epnix/tools/channel-finder/pyCFClient {};
           pyepics = final.callPackage ./epnix/python-modules/pyepics {};
           scanf = final.callPackage ./epnix/tools/scanf {};
         })

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -71,6 +71,8 @@ in
 
       ca-gateway = callPackage ./epnix/tools/ca-gateway {};
 
+      channel-finder-service = callPackage ./epnix/tools/channel-finder/service {};
+
       inherit (final.python3Packages) lewis pyepics;
       inherit (callPackage ./epnix/tools/lewis/lib.nix {}) mkLewisSimulator;
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16,6 +16,7 @@ in
           lewis = final.callPackage ./epnix/tools/lewis {};
           channelfinder = final.callPackage ./epnix/tools/channel-finder/pyCFClient {};
           pyepics = final.callPackage ./epnix/python-modules/pyepics {};
+          recceiver = final.callPackage ./epnix/tools/channel-finder/recceiver {};
           scanf = final.callPackage ./epnix/tools/scanf {};
         })
       ];

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -60,6 +60,7 @@ in
         mrfioc2 = callPackage ./epnix/support/mrfioc2 {};
         opcua = callPackage ./epnix/support/opcua {open62541 = self.open62541_1_3;};
         pvxs = callPackage ./epnix/support/pvxs {};
+        reccaster = callPackage ./epnix/support/reccaster {};
         seq = callPackage ./epnix/support/seq {};
         snmp = callPackage ./epnix/support/snmp {};
         sscan = callPackage ./epnix/support/sscan {};

--- a/pkgs/epnix/support/reccaster/default.nix
+++ b/pkgs/epnix/support/reccaster/default.nix
@@ -1,0 +1,36 @@
+{
+  epnixLib,
+  mkEpicsPackage,
+  fetchFromGitHub,
+  local_config_site ? {},
+  local_release ? {},
+}:
+mkEpicsPackage rec {
+  pname = "RecCaster";
+  version = "1.6";
+  varname = "RECCASTER";
+
+  inherit local_config_site local_release;
+
+  src = fetchFromGitHub {
+    owner = "ChannelFinder";
+    repo = "recsync";
+    rev = "refs/tags/${version}";
+    hash = "sha256-9ApS4e1+oDgZfx7njOuGhezr4ekP2ekJVCc7yiTXRKo=";
+  };
+
+  sourceRoot = "${src.name}/client";
+
+  patches = [./fix-example-shebang.patch];
+
+  postInstall = ''
+    cp -rafv iocBoot -t "$out"
+  '';
+
+  meta = {
+    description = "Informs ChannelFinder of the state of the IOC and the list of PVs contained in that IOC";
+    homepage = "https://channelfinder.readthedocs.io/en/latest/";
+    license = epnixLib.licenses.epics;
+    maintainers = with epnixLib.maintainers; [minijackson];
+  };
+}

--- a/pkgs/epnix/support/reccaster/fix-example-shebang.patch
+++ b/pkgs/epnix/support/reccaster/fix-example-shebang.patch
@@ -1,0 +1,20 @@
+diff --git a/iocBoot/iocdemo/st.cmd b/iocBoot/iocdemo/st.cmd
+index 2dd8cda..4c39612 100755
+--- a/iocBoot/iocdemo/st.cmd
++++ b/iocBoot/iocdemo/st.cmd
+@@ -1,4 +1,4 @@
+-#!../../bin/linux-x86_64-debug/demo
++#!../../bin/linux-x86_64/demo
+ 
+ ## You may have to change demo to something else
+ ## everywhere it appears in this file
+diff --git a/iocBoot/iocdemo/st_test.cmd b/iocBoot/iocdemo/st_test.cmd
+index 420f865..12a74b7 100755
+--- a/iocBoot/iocdemo/st_test.cmd
++++ b/iocBoot/iocdemo/st_test.cmd
+@@ -1,4 +1,4 @@
+-#!../../bin/linux-x86_64-debug/demo
++#!../../bin/linux-x86_64/demo
+ 
+ ## You may have to change demo to something else
+ ## everywhere it appears in this file

--- a/pkgs/epnix/tools/channel-finder/pyCFClient/default.nix
+++ b/pkgs/epnix/tools/channel-finder/pyCFClient/default.nix
@@ -1,0 +1,44 @@
+{
+  epnixLib,
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  python,
+  setuptools,
+  requests,
+  simplejson,
+  urllib3,
+}:
+buildPythonPackage rec {
+  pname = "channelfinder";
+  version = "3.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ChannelFinder";
+    repo = "pyCFClient";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-83V6OgKUgkui1elroKdVr/KBNriSb9nfo8Ggd68AO/Y=";
+  };
+
+  # TODO: when a new version is released, switch to flit-core
+  build-system = [setuptools];
+
+  dependencies = [
+    requests
+    simplejson
+    urllib3
+  ];
+
+  # Tests not run as they need a running ChannelFinder instance
+
+  pythonImportsCheck = ["channelfinder"];
+
+  meta = {
+    description = "Python ChannelFinder Client Lib";
+    homepage = "https://github.com/ChannelFinder/pyCFClient";
+    license = lib.licenses.mit;
+    maintainers = with epnixLib.maintainers; [minijackson];
+    inherit (python.meta) platforms;
+  };
+}

--- a/pkgs/epnix/tools/channel-finder/recceiver/default.nix
+++ b/pkgs/epnix/tools/channel-finder/recceiver/default.nix
@@ -1,0 +1,52 @@
+{
+  epnixLib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  python,
+  setuptools-scm,
+  channelfinder,
+  requests,
+  twisted,
+}:
+buildPythonPackage rec {
+  pname = "RecCeiver";
+  version = "1.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ChannelFinder";
+    repo = "recsync";
+    rev = "refs/tags/${version}";
+    hash = "sha256-9ApS4e1+oDgZfx7njOuGhezr4ekP2ekJVCc7yiTXRKo=";
+  };
+
+  sourceRoot = "${src.name}/server";
+
+  patches = [
+    # Defer Python imports of twisted's reactor, to prevent initializing it,
+    # preventing the error "reactor already installed"
+    # TODO: remove when upgrading to the next release
+    ./fix-reactor-import.patch
+  ];
+
+  build-system = [setuptools-scm];
+
+  dependencies = [
+    channelfinder
+    requests
+    twisted
+  ];
+
+  pythonImportsCheck = [
+    "recceiver"
+    "recceiver.cfstore"
+  ];
+
+  meta = {
+    description = "Collects reccaster reports on the state of IOCs within the corresponding subnet and updates ChannelFinder";
+    homepage = "https://channelfinder.readthedocs.io/en/latest/";
+    license = epnixLib.licenses.epics;
+    maintainers = with epnixLib.maintainers; [minijackson];
+    inherit (python.meta) platforms;
+  };
+}

--- a/pkgs/epnix/tools/channel-finder/recceiver/fix-reactor-import.patch
+++ b/pkgs/epnix/tools/channel-finder/recceiver/fix-reactor-import.patch
@@ -1,0 +1,120 @@
+diff --git a/recceiver/announce.py b/recceiver/announce.py
+index f315e46..10be4a6 100644
+--- a/recceiver/announce.py
++++ b/recceiver/announce.py
+@@ -3,7 +3,7 @@
+ import sys
+ import struct
+ 
+-from twisted.internet import protocol, reactor
++from twisted.internet import protocol
+ import logging
+ 
+ _log = logging.getLogger(__name__)
+@@ -14,12 +14,14 @@
+ __all__ = ['Announcer']
+ 
+ class Announcer(protocol.DatagramProtocol):
+-    reactor = reactor
+-
+     def __init__(self, tcpport, key=0,
+                  tcpaddr='\xff\xff\xff\xff',
+                  udpaddrs=[('<broadcast>',5049)],
+                  period=15.0):
++        from twisted.internet import reactor
++
++        self.reactor = reactor
++
+         if sys.version_info[0] < 3:
+             self.msg = _Ann.pack(0x5243, 0, tcpaddr, tcpport, 0, key)
+         else:
+diff --git a/recceiver/application.py b/recceiver/application.py
+index 50da82b..9bee474 100644
+--- a/recceiver/application.py
++++ b/recceiver/application.py
+@@ -7,7 +7,7 @@
+ 
+ from twisted import plugin
+ from twisted.python import usage, log
+-from twisted.internet import reactor, defer
++from twisted.internet import defer
+ from twisted.internet.error import CannotListenError
+ from twisted.application import service
+ 
+@@ -31,9 +31,12 @@ def flush(self):
+         pass
+ 
+ class RecService(service.MultiService):
+-    reactor = reactor
+ 
+     def __init__(self, config):
++        from twisted.internet import reactor
++
++        self.reactor = reactor
++
+         service.MultiService.__init__(self)
+         self.annperiod = float(config.get('announceInterval', '15.0'))
+         self.tcptimeout = float(config.get('tcptimeout', '15.0'))
+diff --git a/recceiver/recast.py b/recceiver/recast.py
+index 6f6fce2..daa91b4 100644
+--- a/recceiver/recast.py
++++ b/recceiver/recast.py
+@@ -16,7 +16,6 @@
+ from twisted.protocols import stateful
+ from twisted.internet import defer
+ from twisted.internet import protocol
+-from twisted.internet import reactor
+ 
+ from .interfaces import ITransaction
+ 
+@@ -42,11 +41,14 @@
+ 
+ class CastReceiver(stateful.StatefulProtocol):
+ 
+-    reactor = reactor
+     timeout = 3.0
+     version = 0
+ 
+     def __init__(self, active=True):
++        from twisted.internet import reactor
++
++        self.reactor = reactor
++
+         self.sess, self.active = None, active
+         self.uploadSize, self.uploadStart = 0, 0
+ 
+@@ -238,9 +240,12 @@ def __str__(self):
+ class CollectionSession(object):
+     timeout = 5.0
+     trlimit = 0
+-    reactor = reactor
+ 
+     def __init__(self, proto, endpoint):
++        from twisted.internet import reactor
++
++        self.reactor = reactor
++
+         _log.info("Open session from %s",endpoint)
+         self.proto, self.ep = proto, endpoint
+         self.TR = Transaction(self.ep, id(self))
+diff --git a/recceiver/udpbcast.py b/recceiver/udpbcast.py
+index 1f424aa..1b28a61 100644
+--- a/recceiver/udpbcast.py
++++ b/recceiver/udpbcast.py
+@@ -1,6 +1,6 @@
+ # -*- coding: utf-8 -*-
+ 
+-from twisted.internet import udp, reactor
++from twisted.internet import udp
+ from twisted.application import internet
+ 
+ __all__ = ['SharedUDP','SharedUDPServer']
+@@ -29,6 +29,8 @@ class SharedUDPServer(internet.UDPServer):
+     """A UDP server using SharedUDP
+     """
+     def _getPort(self):
++        from twisted.internet import reactor
++
+         R = getattr(self, 'reactor', reactor)
+         port = SharedUDP(reactor=R, *self.args, **self.kwargs)
+         port.startListening()

--- a/pkgs/epnix/tools/channel-finder/service/default.nix
+++ b/pkgs/epnix/tools/channel-finder/service/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  epnixLib,
+  fetchFromGitHub,
+  jre,
+  maven,
+  makeWrapper,
+}:
+maven.buildMavenPackage rec {
+  pname = "ChannelFinderService";
+  version = "4.7.2";
+
+  src = fetchFromGitHub {
+    owner = "ChannelFinder";
+    repo = pname;
+    rev = "refs/tags/ChannelFinder-${version}";
+    hash = "sha256-mRZ9lnkSMSW07GjihDJUDsQFE/f0Sn4T1WbwpUTY16Y=";
+  };
+
+  patches = [./fix-reproducibility.patch];
+
+  mvnHash = "sha256-R5lsFM+yn9xc3Wbpy9Js5r9d7IEOJR301mEoz5SGI/0=";
+  # TODO: remove if this PR is merged:
+  # https://github.com/ChannelFinder/ChannelFinderService/pull/153
+  mvnParameters = "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z";
+
+  nativeBuildInputs = [makeWrapper];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/java
+
+    jarName="ChannelFinder-${version}.jar"
+
+    install -Dm644 "target/$jarName" "$out/share/java"
+
+    makeWrapper ${lib.getExe jre} $out/bin/${meta.mainProgram} \
+      --add-flags "-jar $out/share/java/$jarName"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A RESTful directory services for a list channels";
+    homepage = "https://channelfinder.readthedocs.io/en/latest/";
+    mainProgram = "channel-finder-service";
+    license = lib.licenses.mit;
+    maintainers = with epnixLib.maintainers; [minijackson];
+    inherit (jre.meta) platforms;
+  };
+}

--- a/pkgs/epnix/tools/channel-finder/service/fix-reproducibility.patch
+++ b/pkgs/epnix/tools/channel-finder/service/fix-reproducibility.patch
@@ -1,0 +1,13 @@
+diff --git a/pom.xml b/pom.xml
+index b878804..7894d94 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -230,7 +230,7 @@
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-jar-plugin</artifactId>
+-				<version>3.1.0</version>
++				<version>3.3.0</version>
+                 <configuration>
+                     <archive>
+                         <manifest>

--- a/pkgs/tests/default.nix
+++ b/pkgs/tests/default.nix
@@ -6,4 +6,5 @@
 {pkgs, ...}: {
   channelfinder-default-python = pkgs.python3Packages.channelfinder;
   mrf-driver-default-linux = pkgs.linuxPackages.mrf;
+  recceiver-default-python = pkgs.python3Packages.recceiver;
 }

--- a/pkgs/tests/default.nix
+++ b/pkgs/tests/default.nix
@@ -4,5 +4,6 @@
 # For example kernel modules, which depend on the kernel version,
 # or Python libraries, which depend on the Python version.
 {pkgs, ...}: {
+  channelfinder-default-python = pkgs.python3Packages.channelfinder;
   mrf-driver-default-linux = pkgs.linuxPackages.mrf;
 }


### PR DESCRIPTION
Fixes #17 

- [x] ChannelFinder service package
- [x] ChannelFinder Python module package (needed by RecCeiver)
- [x] RecCeiver package
- [x] RecCaster support module package
- [x] ChannelFinder NixOS module
- [x] RecCeiver NixOS module
- [x] NixOS integration test
- [x] User-guide for integrating RecCaster in an IOC
- [x] User-guide for setting up a ChannelFinder service + RecCeiver server

I did not document the "embedded LDAP" of the ChannelFinder service, since I've had some issues with it.