### PR TITLE
github/update-flake-lock: add nixos-24.05 branch

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         branch:
           - master
+          - nixos-24.05
           - nixos-23.11
           - nixos-23.05
     permissions:


### PR DESCRIPTION
was forgotten during EPNix' 24.05 release