### PR TITLE
fix: remove manpage and pages stages from template CI

### DIFF
--- a/templates/top/.gitlab-ci.yml
+++ b/templates/top/.gitlab-ci.yml
@@ -18,26 +18,3 @@ test:
   script:
     - nix flake check $NIX_BUILD_FLAGS
   dependencies: []
-
-manpage:
-  stage: deploy
-  script:
-    - nix build $NIX_BUILD_FLAGS '.#manpage'
-    - cp -Lr ./result manpage
-  artifacts:
-    name: "manpage-$CI_COMMIT_REF_SLUG"
-    paths:
-      - manpage
-
-pages:
-  stage: deploy
-  script:
-    - nix build $NIX_BUILD_FLAGS '.#mdbook'
-    - cp -Lr ./result public
-  artifacts:
-    name: "mdbook"
-    paths:
-      - public
-  dependencies: []
-  rules:
-    - if: $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH


### PR DESCRIPTION
Manpage and pages build support have been dropped in EPNix 24.05 (I think).

So the associated GitLab stages will cause the CI to fail by default.

This PR simply proposes to remove the manpage and pages CI build stages.