### PR TITLE
github/update-flake-lock: only update master and latest release

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -20,8 +20,6 @@ jobs:
         branch:
           - master
           - nixos-24.05
-          - nixos-23.11
-          - nixos-23.05
     permissions:
       contents: write # to create branch
       pull-requests: write # to create PR to backport


### PR DESCRIPTION
Older releases are not supported upstream, so the nixpkgs input shouldn't update, most of the time