### PR TITLE
github/zizmor: add action that checks actions security

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,33 @@
+# Inspired by:
+# https://woodruffw.github.io/zizmor/usage/#use-in-github-actions
+
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
+      - name: Run zizmor 🌈
+        run: nix run 'nixpkgs#zizmor' -- --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3.27.5
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
This should give us some "Code scanning" alerts when GitHub workflows are implemented poorly.

Note that the backport action will trigger an alert, due to the fact that we have to use `pull_request_target`, which is inherently hard to use securely.

Inspired by:
https://woodruffw.github.io/zizmor/usage/#use-in-github-actions