### PR TITLE
github/zizmor: fix main branch name

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
   pull_request:
     branches: ["**"]
 


### PR DESCRIPTION
the main branch in EPNix is still called "master"