### PR TITLE
support/modbus: 3-2 -> 3-4

### DIFF
--- a/docs/release-notes/2411.rst
+++ b/docs/release-notes/2411.rst
@@ -1,0 +1,15 @@
+24.11 Release notes
+===================
+
+.. role:: nix(code)
+   :language: nix
+
+Breaking changes
+----------------
+
+- the :ref:`pkg-support.modbus` support module was upgraded from 3-2 to 3-4,
+  which changed the name of the ``modbus.dbd`` file.
+  This file wasn't meant to be used,
+  but if you used it by mistake,
+  make sure to include ``modbusSupport.dbd``,
+  and ``drvAsynIPPort.dbd`` or ``drvAsynSerialPort.dbd`` instead.

--- a/pkgs/epnix/support/modbus/default.nix
+++ b/pkgs/epnix/support/modbus/default.nix
@@ -7,14 +7,14 @@
 }:
 mkEpicsPackage rec {
   pname = "modbus";
-  version = "3-2";
+  version = "3-4";
   varname = "MODBUS";
 
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = pname;
-    rev = "R3-2";
-    hash = "sha256-k8MSgNxib4JT0JTbs0BOm75HIVvxHuVPPlo7VcMCnzg=";
+    rev = "R${version}";
+    hash = "sha256-0v6eLWdjgYKbFOHWaW1NSfN/gG5XHVRD9jan55dXWW0=";
   };
 
   propagatedBuildInputs = with epnix.support; [asyn];


### PR DESCRIPTION
and document the upstream change in the `modbus.dbd` -> `modbusApp.dbd`

release notes:

- https://github.com/epics-modules/modbus/blob/master/RELEASE.md#r3-3-december-7-2023
- https://github.com/epics-modules/modbus/blob/master/RELEASE.md#r3-4-december-1-2024