### PR TITLE
github/book-gh-pages: fix master branch name

### DIFF
--- a/.github/workflows/book-gh-pages.yml
+++ b/.github/workflows/book-gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
       # Checkout all documentation versions
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: main
+          ref: master
           path: dev
           persist-credentials: false
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Messed up again, because the main branch is named "main" on my test repo, but "master" in EPNix -_-"