### PR TITLE
Better cross-compilation tests

### DIFF
--- a/ioc/tests/cross/default.nix
+++ b/ioc/tests/cross/default.nix
@@ -19,17 +19,9 @@
   iocBin = "../../bin/${epnixLib.toEpicsArch hostPlatform}/simple";
   emulator = pkgs.lib.replaceStrings ["\""] ["\\\""] (hostPlatform.emulator pkgs);
 in
-  pkgs.nixosTest {
-    name = "cross-for-${system-name}";
+  pkgs.runCommand "cross-for-${system-name}" {
     meta.maintainers = with epnixLib.maintainers; [minijackson];
-
-    nodes.machine = {};
-
-    testScript = ''
-      start_all()
-
-      machine.wait_for_unit("default.target")
-
-      machine.succeed("echo exit | (cd ${ioc}/iocBoot/iocsimple; ${emulator} ${iocBin} ./st.cmd)")
-    '';
-  }
+  } ''
+    echo exit | (cd ${ioc}/iocBoot/iocsimple; ${emulator} ${iocBin} ./st.cmd)
+    mkdir $out
+  ''

--- a/ioc/tests/default.nix
+++ b/ioc/tests/default.nix
@@ -36,6 +36,7 @@ with pkgs.lib;
       # D-TACQ
       {system = "armv7a-linux";}
 
+      aarch64-multiplatform
       raspberryPi
     ];
   in


### PR DESCRIPTION
Now faster since we don't start a whole VM for running just one command,
and add the aarch64 platform, since it's so common these days.