### PR TITLE
GitHub build checks

### DIFF
--- a/.github/workflows/book-gh-pages.yml
+++ b/.github/workflows/book-gh-pages.yml
@@ -50,8 +50,14 @@ jobs:
           path: nixos-24.05
           persist-credentials: false
 
-      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
-      - uses: DeterminateSystems/magic-nix-cache-action@87b14cf437d03d37989d87f0fa5ce4f5dc1a330b # v8
+      - uses: nixbuild/nix-quick-install-action@25aff27c252e0c8cdda3264805f7b6bcd92c8718 # v29
+      - uses: nix-community/cache-nix-action@8351fb9f51c580c96c509987ebb99e38aed956ce # v5.2.1
+        with:
+          primary-key: build-docs-${{ hashFiles('.github/workflows/book-gh-pages.yml', 'flake.lock') }}
+          purge: true
+          purge-last-accessed: 2629800 # 1 month
+          purge-prefixes: build-docs-
+          purge-primary-key: never
 
       - name: "Build documentation books"
         run: |

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -1,0 +1,43 @@
+name: "Nix flake checks"
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  nix-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
+      - id: set-matrix
+        name: Generate Nix checks matrix
+        run: |
+          set -Eeu
+          matrix="$(nix eval --json '.#githubActions.matrix')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  nix-build:
+    name: ${{ matrix.name }} (${{ matrix.system }})
+    needs: nix-matrix
+    runs-on: ${{ matrix.os }}
+    env:
+      CHECK_ATTR: ${{ matrix.attr }}
+    strategy:
+      matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
+      - uses: DeterminateSystems/magic-nix-cache-action@87b14cf437d03d37989d87f0fa5ce4f5dc1a330b # v8
+        with:
+          diagnostic-endpoint: ""
+      - run: nix build -L ".#${CHECK_ATTR}"

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -28,6 +28,8 @@ jobs:
     name: ${{ matrix.name }} (${{ matrix.system }})
     needs: nix-matrix
     runs-on: ${{ matrix.os }}
+    permissions:
+      actions: write
     env:
       CHECK_ATTR: ${{ matrix.attr }}
     strategy:
@@ -36,8 +38,22 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
-      - uses: DeterminateSystems/magic-nix-cache-action@87b14cf437d03d37989d87f0fa5ce4f5dc1a330b # v8
+      - run: |
+          # Enable KVM on Linux so NixOS tests can run.
+          # Do this early in the process so nix installation detects the KVM feature.
+          enable_kvm() {
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-install-nix-action-kvm.rules
+            sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
+          }
+          if [[ "$OSTYPE" =~ linux* ]]; then
+            enable_kvm && echo 'Enabled KVM' || echo 'KVM is not available'
+          fi
+      - uses: nixbuild/nix-quick-install-action@25aff27c252e0c8cdda3264805f7b6bcd92c8718 # v29
+      - uses: nix-community/cache-nix-action@8351fb9f51c580c96c509987ebb99e38aed956ce # v5.2.1
         with:
-          diagnostic-endpoint: ""
+          primary-key: build-${{ runner.os }}-${{ matrix.name }}-${{ hashFiles('.github/workflows/build-checks.yml', 'flake.lock') }}
+          purge: true
+          purge-last-accessed: 2629800 # 1 month
+          purge-prefixes: build-${{ runner.os }}-${{ matrix.name }}-
+          purge-primary-key: never
       - run: nix build -L ".#${CHECK_ATTR}"

--- a/flake.lock
+++ b/flake.lock
@@ -84,6 +84,26 @@
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737420293,
+        "narHash": "sha256-F1G5ifvqTpJq7fdkT34e/Jy9VCyzd5XfJ9TO8fHhJWE=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "f4158fa080ef4503c8f4c820967d946c2af31ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-github-actions_2": {
+      "inputs": {
+        "nixpkgs": [
           "sphinxcontrib-nixdomain",
           "pyproject-nix",
           "nixpkgs"
@@ -122,7 +142,7 @@
     "pyproject-nix": {
       "inputs": {
         "mdbook-nixdoc": "mdbook-nixdoc",
-        "nix-github-actions": "nix-github-actions",
+        "nix-github-actions": "nix-github-actions_2",
         "nixpkgs": [
           "sphinxcontrib-nixdomain",
           "nixpkgs"
@@ -146,6 +166,7 @@
       "inputs": {
         "bash-lib": "bash-lib",
         "flake-utils": "flake-utils_2",
+        "nix-github-actions": "nix-github-actions",
         "nixpkgs": "nixpkgs",
         "sphinxcontrib-nixdomain": "sphinxcontrib-nixdomain"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,12 +12,17 @@
       url = "github:minijackson/sphinxcontrib-nixdomain";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nix-github-actions = {
+      url = "github:nix-community/nix-github-actions";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
     self,
     flake-utils,
     nixpkgs,
+    nix-github-actions,
     ...
   } @ inputs: let
     overlay = import ./pkgs self.lib inputs;
@@ -121,5 +126,7 @@
       templates.default = self.templates.top;
 
       formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.alejandra;
+
+      githubActions = nix-github-actions.lib.mkGithubMatrix {inherit (self) checks;};
     };
 }


### PR DESCRIPTION
Enables us to see the result of checks directly on GitHub.

It's really not optimized, since it will compile for example epics-base for each check that needs it (~20 times), but it should be a nice stopgap solution until we deploy our own public CI and cache server.

~~Also add `x86_64-darwin` to supported system, in case we want to support MacOS developers.~~
It seems there's some work to do for MacOS support…