### PR TITLE
nixos/phoebus-olog: use FerretDB intead of MongoDB

### DIFF
--- a/docs/release-notes/2411.rst
+++ b/docs/release-notes/2411.rst
@@ -13,3 +13,40 @@ Breaking changes
   but if you used it by mistake,
   make sure to include ``modbusSupport.dbd``,
   and ``drvAsynIPPort.dbd`` or ``drvAsynSerialPort.dbd`` instead.
+
+- :nix:option:`services.phoebus-olog` now uses FerretDB instead of MongoDB,
+  which prevents having to compile a resource intensive project
+  due to its license.
+  Migrate your data by following :ref:`mongodb-to-ferretdb`.
+
+Detailed migration information
+------------------------------
+
+.. _mongodb-to-ferretdb:
+
+From MongoDB to FerretDB
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Before upgrading to ``nixos-24.11``,
+install the ``mongodb-tools`` package,
+by adding it to your ``environment.systemPackages``.
+
+On the target machine,
+run:
+
+.. code-block:: bash
+
+   mkdir mongodb-dump
+   cd mongodb-dump
+   mongodump
+
+Then,
+upgrade your system to ``nixos-24.11``.
+
+On the target machine,
+run:
+
+.. code-block:: bash
+
+   cd mongodb-dump
+   mongorestore

--- a/nixos/modules/phoebus/olog.nix
+++ b/nixos/modules/phoebus/olog.nix
@@ -105,7 +105,7 @@ in {
       description = "Phoebus Alarm Server";
 
       wantedBy = ["multi-user.target"];
-      after = ["elasticsearch.service" "mongodb.service"];
+      after = ["elasticsearch.service" "ferretdb.service"];
 
       serviceConfig = {
         ExecStart = "${lib.getExe pkgs.epnix.phoebus-olog} --spring.config.location=file://${configFile}";
@@ -113,7 +113,10 @@ in {
         # TODO: systemd hardening. Currently level 8.2 EXPOSED
       };
     };
-    services.mongodb.enable = true;
+    services.ferretdb = {
+      enable = true;
+      settings.FERRETDB_TELEMETRY = "disable";
+    };
   };
 
   meta.maintainers = with epnixLib.maintainers; [minijackson];

--- a/nixos/tests/phoebus/olog.nix
+++ b/nixos/tests/phoebus/olog.nix
@@ -24,9 +24,6 @@
           # not open-source. But as we're using it run tests, not exposing
           # any service, this should be fine.
           "elasticsearch"
-
-          # MongoDB also uses the SSPL.
-          "mongodb"
         ];
 
       networking.firewall.allowedTCPPorts = [8181];
@@ -56,7 +53,7 @@
     with subtest("Olog connected to ElasticSearch"):
         assert status["elastic"]["status"] == "Connected"
 
-    with subtest("Olog connected to MongoDB"):
+    with subtest("Olog connected to MongoDB (FerretDB)"):
         assert "state=CONNECTED" in status["mongoDB"]
 
     def get(uri: str) -> Any:


### PR DESCRIPTION
To prevent having to compile MongoDB, which requires a lot of resources