### PR TITLE
Phoebus related improvements

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -117,7 +117,7 @@ in
       phoebus-pva = callPackage ./epnix/tools/phoebus/pva {};
       phoebus-save-and-restore = callPackage ./epnix/tools/phoebus/save-and-restore {};
       phoebus-scan-server = callPackage ./epnix/tools/phoebus/scan-server {};
-      phoebus-setup-hook = callPackage ./epnix/tools/phoebus/setup-hook {jdk = prev.jdk21;};
+      phoebus-setup-hook = callPackage ./epnix/tools/phoebus/setup-hook {jdk = prev.jdk21_headless;};
 
       procServ = callPackage ./epnix/tools/procServ {};
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -106,17 +106,19 @@ in
       pcas = callPackage ./epnix/tools/pcas {};
 
       phoebus = callPackage ./epnix/tools/phoebus/client {
+        jdk = prev.jdk21;
         openjfx = prev.openjfx21;
       };
       phoebus-alarm-server = callPackage ./epnix/tools/phoebus/alarm-server {};
       phoebus-alarm-logger = callPackage ./epnix/tools/phoebus/alarm-logger {};
       phoebus-archive-engine = callPackage ./epnix/tools/phoebus/archive-engine {};
-      phoebus-deps = callPackage ./epnix/tools/phoebus/deps {};
-      phoebus-olog = callPackage ./epnix/tools/phoebus/olog {};
+      phoebus-deps = callPackage ./epnix/tools/phoebus/deps {jdk = prev.jdk21;};
+      phoebus-olog = callPackage ./epnix/tools/phoebus/olog {jdk = prev.jdk21;};
       phoebus-pva = callPackage ./epnix/tools/phoebus/pva {};
       phoebus-save-and-restore = callPackage ./epnix/tools/phoebus/save-and-restore {};
       phoebus-scan-server = callPackage ./epnix/tools/phoebus/scan-server {};
-      phoebus-setup-hook = callPackage ./epnix/tools/phoebus/setup-hook {};
+      phoebus-setup-hook = callPackage ./epnix/tools/phoebus/setup-hook {jdk = prev.jdk21;};
+
       procServ = callPackage ./epnix/tools/procServ {};
 
       # Other utilities

--- a/pkgs/epnix/tools/phoebus/alarm-logger/default.nix
+++ b/pkgs/epnix/tools/phoebus/alarm-logger/default.nix
@@ -5,7 +5,6 @@
   maven,
   makeWrapper,
   epnix,
-  jdk,
 }: let
   buildDate = "2022-02-24T07:56:00Z";
 in
@@ -53,6 +52,6 @@ in
       mainProgram = "phoebus-alarm-logger";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
-      inherit (jdk.meta) platforms;
+      inherit (epnix.phoebus-setup-hook.meta) platforms;
     };
   }

--- a/pkgs/epnix/tools/phoebus/alarm-server/default.nix
+++ b/pkgs/epnix/tools/phoebus/alarm-server/default.nix
@@ -5,7 +5,6 @@
   maven,
   makeWrapper,
   epnix,
-  jdk,
 }: let
   buildDate = "2022-02-24T07:56:00Z";
 in
@@ -56,6 +55,6 @@ in
       mainProgram = "phoebus-alarm-server";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
-      inherit (jdk.meta) platforms;
+      inherit (epnix.phoebus-setup-hook.meta) platforms;
     };
   }

--- a/pkgs/epnix/tools/phoebus/archive-engine/default.nix
+++ b/pkgs/epnix/tools/phoebus/archive-engine/default.nix
@@ -5,7 +5,6 @@
   maven,
   makeWrapper,
   epnix,
-  jdk,
 }: let
   buildDate = "2022-02-24T07:56:00Z";
 in
@@ -53,6 +52,6 @@ in
       mainProgram = "phoebus-archive-engine";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
-      inherit (jdk.meta) platforms;
+      inherit (epnix.phoebus-setup-hook.meta) platforms;
     };
   }

--- a/pkgs/epnix/tools/phoebus/client/default.nix
+++ b/pkgs/epnix/tools/phoebus/client/default.nix
@@ -30,7 +30,6 @@ in
       maven
       copyDesktopItems
       makeWrapper
-      (epnix.phoebus-setup-hook.override {jdk = jdk.override {enableJavaFX = true;};})
       (epnix.phoebus-setup-hook.override {
         jdk = jdk.override {
           enableJavaFX = true;

--- a/pkgs/epnix/tools/phoebus/olog/default.nix
+++ b/pkgs/epnix/tools/phoebus/olog/default.nix
@@ -2,7 +2,7 @@
   lib,
   epnixLib,
   fetchFromGitHub,
-  jre,
+  jdk,
   maven,
   makeWrapper,
 }:
@@ -32,7 +32,7 @@ maven.buildMavenPackage rec {
 
     install -Dm644 target/service-olog-${version}.jar $out/share/java
 
-    makeWrapper ${lib.getExe jre} $out/bin/${meta.mainProgram} \
+    makeWrapper ${lib.getExe jdk} $out/bin/${meta.mainProgram} \
       --add-flags "-jar $out/share/java/$jarName"
 
     runHook postInstall
@@ -44,6 +44,6 @@ maven.buildMavenPackage rec {
     mainProgram = "phoebus-olog";
     license = lib.licenses.epl10;
     maintainers = with epnixLib.maintainers; [minijackson];
-    inherit (jre.meta) platforms;
+    inherit (jdk.meta) platforms;
   };
 }

--- a/pkgs/epnix/tools/phoebus/pva/default.nix
+++ b/pkgs/epnix/tools/phoebus/pva/default.nix
@@ -5,7 +5,6 @@
   maven,
   makeWrapper,
   epnix,
-  jdk,
 }: let
   buildDate = "2022-02-24T07:56:00Z";
 in
@@ -53,6 +52,6 @@ in
       mainProgram = "phoebus-pva";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
-      inherit (jdk.meta) platforms;
+      inherit (epnix.phoebus-setup-hook.meta) platforms;
     };
   }

--- a/pkgs/epnix/tools/phoebus/save-and-restore/default.nix
+++ b/pkgs/epnix/tools/phoebus/save-and-restore/default.nix
@@ -5,7 +5,6 @@
   maven,
   makeWrapper,
   epnix,
-  jdk,
 }: let
   buildDate = "2022-02-24T07:56:00Z";
 in
@@ -53,6 +52,6 @@ in
       mainProgram = "phoebus-save-and-restore";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
-      inherit (jdk.meta) platforms;
+      inherit (epnix.phoebus-setup-hook.meta) platforms;
     };
   }

--- a/pkgs/epnix/tools/phoebus/scan-server/default.nix
+++ b/pkgs/epnix/tools/phoebus/scan-server/default.nix
@@ -5,7 +5,6 @@
   maven,
   makeWrapper,
   epnix,
-  jdk,
 }: let
   buildDate = "2022-02-24T07:56:00Z";
 in
@@ -53,6 +52,6 @@ in
       mainProgram = "phoebus-scan-server";
       license = lib.licenses.epl10;
       maintainers = with epnixLib.maintainers; [minijackson];
-      inherit (jdk.meta) platforms;
+      inherit (epnix.phoebus-setup-hook.meta) platforms;
     };
   }

--- a/pkgs/epnix/tools/phoebus/setup-hook/default.nix
+++ b/pkgs/epnix/tools/phoebus/setup-hook/default.nix
@@ -13,6 +13,7 @@ makeSetupHook {
     description = "Common Bash functions for building components of the Phoebus project";
     maintainers = with epnixLib.maintainers; [minijackson];
     hidden = true;
+    inherit (jdk.meta) platforms;
   };
 }
 ./setup-hook.sh


### PR DESCRIPTION
Notably:

- Explicitely hardcode the JDK version to make it clearer which version we use
- Use a lighter JDK by default so that Phoebus services don't depend on graphical libraries