### PR TITLE
epics-base: 7.0.8.1 -> 7.0.9

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -39,8 +39,8 @@ in
       # EPICS base
 
       epics-base7 = callPackage ./epnix/epics-base {
-        version = "7.0.8.1";
-        hash = "sha256-JDSMBwBLZj9aaxJHGg0QmZ1zYTSY8J7+ZGihAwEuz3w=";
+        version = "7.0.9";
+        hash = "sha256-RPlJhh7ORobYlM7gq6uDZkrO5z579Q7hyLEQ1xiHvFY=";
       };
       epics-base3 = callPackage ./epnix/epics-base {
         version = "3.15.9";

--- a/pkgs/epnix/epics-base/default.nix
+++ b/pkgs/epnix/epics-base/default.nix
@@ -4,7 +4,7 @@
   epnixLib,
   buildPackages,
   mkEpicsPackage,
-  fetchgit,
+  fetchFromGitHub,
   version,
   hash,
   local_config_site ? {},
@@ -29,10 +29,12 @@ in
 
     isEpicsBase = true;
 
-    src = fetchgit {
-      url = "https://git.launchpad.net/epics-base";
-      rev = "R${version}";
+    src = fetchFromGitHub {
+      owner = "epics-base";
+      repo = "epics-base";
+      tag = "R${version}";
       inherit hash;
+      fetchSubmodules = true;
     };
 
     patches = optionals (older "7.0.5") [

--- a/pkgs/epnix/epics-base/default.nix
+++ b/pkgs/epnix/epics-base/default.nix
@@ -5,7 +5,6 @@
   buildPackages,
   mkEpicsPackage,
   fetchgit,
-  fetchpatch,
   version,
   hash,
   local_config_site ? {},
@@ -13,7 +12,6 @@
 }:
 with lib; let
   older = versionOlder version;
-  atLeast = versionAtLeast version;
 
   generateConf = (epnixLib.formats.make {}).generate;
 
@@ -135,16 +133,6 @@ in
 
     # TODO: Some tests fail
     doCheck = false;
-
-    # _FORTIFY_SOURCE=3 detects a false-positive buffer overflow in some cases:
-    #     *** buffer overflow detected ***: terminated
-    #
-    # EPICS automatically falls back to _FORTIFY_SOURCE=2 since 7.0.8.1, but this doesn't work in
-    # the nix build.
-    # Being tracked in https://github.com/epics-base/epics-base/issues/514, hopefully with a fix
-    # in EPICS 7.0.9
-
-    hardeningDisable = ["fortify3"];
 
     meta = {
       description = "The Experimental Physics and Industrial Control System";


### PR DESCRIPTION
re-enabled the fortify3 compilation option,
since it was fixed upstream