### PR TITLE
Use maven.test.skip instead of skipTests for phoebus builds

### DIFF
--- a/pkgs/epnix/tools/phoebus/alarm-logger/default.nix
+++ b/pkgs/epnix/tools/phoebus/alarm-logger/default.nix
@@ -27,7 +27,7 @@ in
         --projects "./services/alarm-logger" \
         --also-make \
         --offline \
-        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -DskipTests \
+        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.skip \
         -Dproject.build.outputTimestamp=${buildDate} \
         -Dmaven.repo.local="$deps"
 

--- a/pkgs/epnix/tools/phoebus/alarm-server/default.nix
+++ b/pkgs/epnix/tools/phoebus/alarm-server/default.nix
@@ -30,7 +30,7 @@ in
         --projects "./services/alarm-server" \
         --also-make \
         --offline \
-        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -DskipTests \
+        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.skip \
         -Dproject.build.outputTimestamp=${buildDate} \
         -Dmaven.repo.local="$deps"
 

--- a/pkgs/epnix/tools/phoebus/archive-engine/default.nix
+++ b/pkgs/epnix/tools/phoebus/archive-engine/default.nix
@@ -27,7 +27,7 @@ in
         --projects "./services/archive-engine" \
         --also-make \
         --offline \
-        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -DskipTests \
+        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.skip \
         -Dproject.build.outputTimestamp=${buildDate} \
         -Dmaven.repo.local="$deps"
 

--- a/pkgs/epnix/tools/phoebus/client-unwrapped/default.nix
+++ b/pkgs/epnix/tools/phoebus/client-unwrapped/default.nix
@@ -57,7 +57,7 @@ in
         --projects "./phoebus-product" \
         --also-make \
         --offline \
-        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -DskipTests \
+        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.skip \
         -Dproject.build.outputTimestamp=${buildDate} \
         -Dmaven.repo.local="$deps"
 

--- a/pkgs/epnix/tools/phoebus/deps/default.nix
+++ b/pkgs/epnix/tools/phoebus/deps/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   buildPhase = ''
     runHook preBuild
 
-    mvn package -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -DskipTests -Dmaven.repo.local=$out
+    mvn package -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.skip -Dmaven.repo.local=$out
 
     runHook postBuild
   '';

--- a/pkgs/epnix/tools/phoebus/pva/default.nix
+++ b/pkgs/epnix/tools/phoebus/pva/default.nix
@@ -27,7 +27,7 @@ in
         --projects "./core/pva" \
         --also-make \
         --offline \
-        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -DskipTests \
+        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.skip \
         -Dproject.build.outputTimestamp=${buildDate} \
         -Dmaven.repo.local="$deps"
 

--- a/pkgs/epnix/tools/phoebus/save-and-restore/default.nix
+++ b/pkgs/epnix/tools/phoebus/save-and-restore/default.nix
@@ -27,7 +27,7 @@ in
         --projects "./services/save-and-restore" \
         --also-make \
         --offline \
-        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -DskipTests \
+        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.skip \
         -Dproject.build.outputTimestamp=${buildDate} \
         -Dmaven.repo.local="$deps"
 

--- a/pkgs/epnix/tools/phoebus/scan-server/default.nix
+++ b/pkgs/epnix/tools/phoebus/scan-server/default.nix
@@ -27,7 +27,7 @@ in
         --projects "./services/scan-server" \
         --also-make \
         --offline \
-        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -DskipTests \
+        -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dmaven.test.skip \
         -Dproject.build.outputTimestamp=${buildDate} \
         -Dmaven.repo.local="$deps"
 


### PR DESCRIPTION
Using this flag instead skips test compilation, which reduces build times by about 25% on my machine. The build times for phoebus get kind of long on our gitlab runners (~15 minutes), so reducing it by a significant amount may be helpful.

Documentation does say that it is not recommended to use this flag, but especially for the phoebus-deps package, it seems unnecessary to compile the tests, when they are not even going to be ran. 

See also [the documentation](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#skip) and [this SO post](https://stackoverflow.com/questions/2593588/maven-skip-building-test-classes).