### PR TITLE
IOC service NixOS module

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,8 @@ exclude_patterns = [
 pygments_style = "pygments_styles.EpnixNordLight"
 pygments_dark_style = "pygments_styles.EpnixNordDarker"
 
+manpages_url = "https://manpages.debian.org/{path}"
+
 # -- Options for MyST --------------------------------------------------------
 # https://myst-parser.readthedocs.io/en/latest/configuration.html
 

--- a/docs/nixos-services/options-reference/ioc-services.rst
+++ b/docs/nixos-services/options-reference/ioc-services.rst
@@ -1,0 +1,8 @@
+IOC services
+============
+
+.. seealso::
+   To learn how to deploy IOCs on NixOS,
+   read the :doc:`../user-guides/ioc-services` guide.
+
+.. nix:automodule:: services.iocs

--- a/docs/nixos-services/user-guides/index.rst
+++ b/docs/nixos-services/user-guides/index.rst
@@ -8,9 +8,7 @@ User guides
 ----
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
+   :glob:
 
-   ./ca-gateway.rst
-   ./channel-finder.rst
-   ./phoebus-alarm.rst
-   ./phoebus-save-and-restore.rst
+   *

--- a/docs/nixos-services/user-guides/ioc-services.rst
+++ b/docs/nixos-services/user-guides/ioc-services.rst
@@ -277,3 +277,38 @@ and the man pages :manpage:`systemd.unit(5)`,
 and other related systemd documentation.
 
 .. _systemd.services options: https://search.nixos.org/options?query=systemd.services.
+
+Systemd hardening
+^^^^^^^^^^^^^^^^^
+
+By default,
+the :nix:option:`services.iocs` module configures some systemd security hardening options.
+For example,
+the IOC can't change the system clock,
+or change the machine's hostname.
+
+To examine the list of the enabled systemd hardening options,
+examine the :file:`nixos/modules/iocs.nix` file in the EPNix source code.
+
+You can turn off systemd hardening options by overriding the setting:
+
+.. code-block:: nix
+   :caption: Turning off a systemd hardening option
+
+     services.iocs.myIoc = {
+       package = pkgs.myTop;
+       workingDirectory = "iocBoot/iocMyIoc";
+     };
+
+     # These options will modify the generated systemd service
+     systemd.services.myIoc = {
+       # In the [Service] section,
+       # ProtectClock was enabled by default,
+       # but we override it here
+       # to allow the IOC to change the system clock:
+       serviceConfig.ProtectClock = false;
+     };
+
+For more information about hardening options,
+examine the man pages :manpage:`systemd.exec(5)`
+and :manpage:`systemd.resource-control(5)`.

--- a/docs/nixos-services/user-guides/ioc-services.rst
+++ b/docs/nixos-services/user-guides/ioc-services.rst
@@ -1,0 +1,279 @@
+IOC services
+============
+
+This guide covers how to install EPICS IOCs as a systemd service
+on a NixOS machine.
+
+.. include:: ./pre-requisites.rst
+
+Exposing a service from your IOC
+--------------------------------
+
+If your EPICS top and your NixOS configuration are in two different repositories,
+the recommended way to integrate your IOC is
+to add the configuration inside your EPICS top repository.
+This configuration will be exposed,
+so that you can use it inside your NixOS configuration repository.
+
+From your EPICS top repository,
+make sure your :file:`flake.nix` has these lines:
+
+.. code-block:: nix
+   :caption: :file:`flake.nix` --- Exposed NixOS settings from your EPICS top
+   :emphasize-lines: 5-12
+
+         overlays.default = final: _prev: {
+           myIoc = final.callPackage ./ioc.nix {};
+         };
+
+         nixosModules.iocService = {config, ...}: {
+           services.iocs.myIoc = {
+             description = "An optional description of your IOC";
+             package = self.packages.x86_64-linux.default;
+             # Directory where to find the 'st.cmd' file
+             workingDirectory = "iocBoot/iocMyIoc";
+           };
+         };
+
+Make sure ``description`` and ``workingDirectory`` are correct.
+The ``workingDirectory`` must point
+to the directory containing the ``st.cmd`` file to run.
+
+If you need a file other than ``st.cmd``,
+see :ref:`custom_cmd`.
+
+.. seealso::
+   For a complete list of all IOC service-related options,
+   see :nix:option:`services.iocs`.
+
+Importing the exposed service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+From your NixOS configuration repository,
+in your :file:`flake.nix`,
+add your EPICS top as a flake input,
+and import the exposed service:
+
+.. code-block:: nix
+   :caption: :file:`flake.nix` --- Importing the IOC service from your NixOS configuration
+   :emphasize-lines: 5,12,17
+
+   {
+     # ...
+     inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+     inputs.epnix.url = "github:epics-extensions/EPNix/nixos-24.11";
+     inputs.myTop.url = "git+ssh://git@my-gitlab-server.com/EPICS/myTop.git";
+
+     # ...
+     outputs = {
+       self,
+       nixpkgs,
+       epnix,
+       myTop,
+     }: {
+       nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
+         modules = [
+           epnix.nixosModules.nixos
+           myTop.nixosModules.iocService
+
+           # ...
+         ];
+       };
+     };
+   }
+
+Then apply your NixOS configuration.
+
+Adding an external IOC
+----------------------
+
+As an alternative,
+if the IOC you want to run doesn't expose a pre-configured service,
+or if you don't wan't to use that configuration,
+you can define it directly in your NixOS configuration.
+
+From your NixOS configuration repository,
+add your EPICS top to your flake inputs and overlays.
+For example:
+
+.. code-block:: nix
+   :caption: :file:`flake.nix` --- Adding your top to your flake inputs and overlays
+   :emphasize-lines: 5,12,19-28
+
+   {
+     # ...
+     inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+     inputs.epnix.url = "github:epics-extensions/EPNix/nixos-24.11";
+     inputs.myTop.url = "git+ssh://git@my-gitlab-server.com/EPICS/myTop.git";
+
+     # ...
+     outputs = {
+       self,
+       nixpkgs,
+       epnix,
+       myTop,
+     }: {
+       nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
+         modules = [
+           epnix.nixosModules.nixos
+           # ...
+
+           {
+             nixpkgs.overlays = [
+               (final: prev: {
+                 # Add 'myTop' to the set of 'pkgs'
+                 myTop = myTop.packages.x86_64-linux.default;
+                 # Add your other tops here, for example:
+                 #myOtherTop = myOtherTop.packages.x86_64-linux.default;
+               })
+             ];
+           }
+         ];
+       };
+     };
+   }
+
+Then create an :file:`{myIoc}.nix` file:
+
+.. code-block:: nix
+   :caption: :file:`{myIoc}.nix` --- IOC configuration example
+
+   { pkgs, ... }:
+   {
+     # Replace 'myIoc' below with the name of your IOC
+     services.iocs.myIoc = {
+       description = "An optional description of your IOC";
+       package = pkgs.myTop;
+       # Directory where to find the 'st.cmd' file
+       workingDirectory = "iocBoot/iocMyIoc";
+     };
+   }
+
+Make sure to import it in your :file:`flake.nix`.
+
+.. seealso::
+   For a list of all IOC-related options,
+   see :nix:option:`services.iocs`.
+
+.. _custom_cmd:
+
+Custom cmd file
+---------------
+
+If your IOC is started through a script other than a file :file:`st.cmd`,
+set the option :nix:option:`services.iocs.<name>.startupScript` to you cmd script.
+
+Custom procServ options
+-----------------------
+
+To change the procServ port,
+use :nix:option:`services.iocs.<name>.procServ.port`.
+
+To change or add procServ options,
+use :nix:option:`services.iocs.<name>.procServ.options`.
+
+For example:
+
+.. code-block:: nix
+   :caption: Changing the default ``procServ`` options
+
+     services.iocs.myIoc = {
+       package = pkgs.myTop;
+       # Directory where to find the 'st.cmd' file
+       workingDirectory = "iocBoot/iocMyIoc";
+
+       procServ = {
+         # Set the port procServ listens to
+         port = 2001;
+         # Add an option `--killcmd "^b"`
+         options.killcmd = "^b";
+       };
+     };
+
+Passing environment variables
+-----------------------------
+
+You can set environment variables for your IOC
+by using the option :nix:option:`services.iocs.<name>.environment`.
+For example:
+
+.. code-block:: nix
+   :caption: Setting environment variables
+   :emphasize-lines: 5
+
+     services.iocs.myIoc = {
+       package = pkgs.myTop;
+       workingDirectory = "iocBoot/iocMyIoc";
+
+       environment.EPICS_CA_MAX_ARRAY_BYTES = 10000;
+     };
+
+Adding programs to the PATH
+---------------------------
+
+If your IOC calls external programs,
+you need to add those programs to your IOC's PATH.
+
+To do this,
+use the option :nix:option:`services.iocs.<name>.path`.
+For example:
+
+.. code-block:: nix
+   :caption: Adding programs to the IOC's PATH
+   :emphasize-lines: 1,7
+
+   {pkgs, ...}:
+   {
+     services.iocs.myIoc = {
+       package = pkgs.myTop;
+       workingDirectory = "iocBoot/iocMyIoc";
+
+       path = [pkgs.pciutils];
+     };
+   }
+
+.. tip::
+
+   Programs installed via the ``environment.systemPackages`` option are *not* available
+   to systemd services.
+
+Further customization
+---------------------
+
+For other customization of IOC services,
+you can edit the generated systemd service
+by setting the options under :samp:`systemd.services.{myIoc}`.
+
+For example,
+to make your machine reboot
+if your IOC fails to start:
+
+.. code-block:: nix
+   :caption: Customizing the IOC systemd service
+
+     services.iocs.myIoc = {
+       package = pkgs.myTop;
+       workingDirectory = "iocBoot/iocMyIoc";
+     };
+
+     # These options will modify the generated systemd service
+     systemd.services.myIoc = {
+       # These options will modify the [Unit] section
+       # See `man systemd.unit` for available options in this section
+       unitConfig = {
+         # If the IOC reboot 5 times
+         StartLimitBurst = 5;
+         # in 30 seconds
+         StartLimitIntervalSec = 30;
+         # reboot
+         StartLimitAction = "reboot";
+       };
+     };
+
+For more information,
+examine the `systemd.services options`_,
+and the man pages :manpage:`systemd.unit(5)`,
+:manpage:`systemd.service(5)`,
+and other related systemd documentation.
+
+.. _systemd.services options: https://search.nixos.org/options?query=systemd.services.

--- a/docs/release-notes/2505.rst
+++ b/docs/release-notes/2505.rst
@@ -6,6 +6,17 @@
 .. role:: nix(code)
    :language: nix
 
+New features
+------------
+
+- New module :option:`services.iocs`
+  to deploy EPICS IOCs as systemd services.
+
+  If you deployed EPICS IOCs manually by using ``systemd.services``,
+  or used the configuration :samp:`epnix.nixos.services.{ioc}.config`
+  generated from the now deprecated IOC module system,
+  read the :doc:`../nixos-services/user-guides/ioc-services` NixOS guide.
+
 Breaking changes
 ----------------
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -17,6 +17,11 @@ with lib; let
 
     inherit (self.evaluation) evalEpnixModules mkEpnixBuild mkEpnixDevShell;
 
+    # The epnix nixosModules.nixos flake output,
+    # re-exposed in epnixLib,
+    # in case you're not in flake.nix.
+    nixosModule = self.inputs.self.nixosModules.nixos;
+
     # Like lib.getName, but also supports paths
     getName = thing:
       if builtins.isPath thing

--- a/nixos/module-list.nix
+++ b/nixos/module-list.nix
@@ -3,6 +3,7 @@
   ./modules/ca-gateway.nix
   ./modules/channel-finder/recceiver.nix
   ./modules/channel-finder/service.nix
+  ./modules/iocs.nix
   ./modules/phoebus/alarm-logger.nix
   ./modules/phoebus/alarm-server.nix
   ./modules/phoebus/client.nix

--- a/nixos/modules/iocs.nix
+++ b/nixos/modules/iocs.nix
@@ -140,9 +140,10 @@
 
         wantedBy = lib.mkIf config.enable (lib.mkDefault ["multi-user.target"]);
 
-        # When initializing the IOC, PV Access looks for network interfaces that
-        # have IP addresses. "network.target" may be too early, especially for
-        # systems with DHCP.
+        # When initializing the IOC,
+        # PV Access looks for network interfaces that have IP addresses.
+        # "network.target" may be too early,
+        # especially for systems with DHCP.
         wants = lib.mkDefault ["network-online.target"];
         after = lib.mkDefault ["network-online.target"];
 
@@ -150,8 +151,6 @@
         unitConfig.StartLimitIntervalSec = lib.mkDefault "0";
 
         serviceConfig = {
-          Restart = "always";
-          RestartSec = lib.mkDefault "1s";
           ExecStart = let
             procServ = lib.getExe pkgs.epnix.procServ;
           in ''
@@ -160,8 +159,53 @@
               ${config.startupScript}
           '';
 
-          DynamicUser = true;
+          Restart = lib.mkDefault "always";
+          RestartSec = lib.mkDefault "1s";
           StateDirectory = ["epics/${name}"];
+
+          # Hardening options,
+          # can be disabled by the end user, if needed
+
+          DynamicUser = lib.mkDefault true;
+
+          PrivateUsers = lib.mkDefault true;
+          PrivateMounts = lib.mkDefault true;
+
+          ProtectKernelLogs = lib.mkDefault true;
+          ProtectKernelModules = lib.mkDefault true;
+          ProtectKernelTunables = lib.mkDefault true;
+          ProtectClock = lib.mkDefault true;
+          ProtectControlGroups = lib.mkDefault true;
+          ProtectHostname = lib.mkDefault true;
+          ProtectHome = lib.mkDefault true;
+          ProtectProc = lib.mkDefault true;
+
+          RestrictNamespaces = lib.mkDefault true;
+
+          LockPersonality = lib.mkDefault true;
+
+          SystemCallArchitectures = lib.mkDefault "native";
+
+          # Don't allow these syscalls by default
+          SystemCallFilter = lib.mkDefault [
+            "~@clock"
+            "~@cpu-emulation"
+            "~@debug"
+            "~@module"
+            "~@obsolete"
+            "~@reboot"
+            "~@swap"
+          ];
+          # Don't allow these capabilities by default
+          CapabilityBoundingSet = lib.mkDefault [
+            "~CAP_SYS_PACCT"
+            "~CAP_SETUID"
+            "~CAP_SETGID"
+            "~CAP_SETPCAP"
+            "~CAP_SYS_PTRACE"
+            "~CAP_NET_ADMIN"
+            "~CAP_SYS_ADMIN"
+          ];
         };
       };
 

--- a/nixos/modules/iocs.nix
+++ b/nixos/modules/iocs.nix
@@ -177,11 +177,20 @@ in {
     '';
   };
 
-  config.systemd.services =
-    lib.mapAttrs'
-    (_name: iocCfg: {
-      inherit (iocCfg) name;
-      value = iocCfg.generatedSystemdService;
-    })
-    config.services.iocs;
+  config = {
+    systemd.services =
+      lib.mapAttrs'
+      (_name: iocCfg: {
+        inherit (iocCfg) name;
+        value = iocCfg.generatedSystemdService;
+      })
+      config.services.iocs;
+
+    # If there's at least one IOC configured,
+    # add telnet to the environment,
+    # to be able to connect to procServ
+    environment.systemPackages = lib.mkIf (config.services.iocs != {}) [
+      pkgs.inetutils
+    ];
+  };
 }

--- a/templates/new-top/checks/simple.nix
+++ b/templates/new-top/checks/simple.nix
@@ -2,25 +2,27 @@
   nixosTest,
   epnix,
   epnixLib,
-  myIoc,
+  iocService,
   ...
 }:
 nixosTest {
   name = "simple";
 
   nodes.machine = {
-    imports = [epnixLib.inputs.self.nixosModules.nixos];
-    environment.systemPackages = [epnix.epics-base];
+    imports = [
+      epnixLib.nixosModule
 
-    services.iocs.myIoc = {
-      package = myIoc;
-      workingDirectory = "iocBoot/iocMyIoc";
-    };
+      # Import the IOC service,
+      # as defined in flake.nix' nixosModules.iocService
+      iocService
+    ];
+
+    environment.systemPackages = [epnix.epics-base];
   };
 
   testScript = ''
     machine.wait_for_unit("default.target")
-    machine.wait_for_unit("ioc.service")
+    machine.wait_for_unit("myIoc.service")
 
     machine.wait_until_succeeds("caget stringin", timeout=10)
     machine.wait_until_succeeds("caget stringout", timeout=10)

--- a/templates/new-top/flake.nix
+++ b/templates/new-top/flake.nix
@@ -42,12 +42,23 @@
       packages.default = pkgs.myIoc;
 
       checks = {
-        simple = pkgs.callPackage ./checks/simple.nix {};
+        simple = pkgs.callPackage ./checks/simple.nix {
+          inherit (self.nixosModules) iocService;
+        };
       };
     })
     // {
       overlays.default = final: _prev: {
         myIoc = final.callPackage ./ioc.nix {};
+      };
+
+      nixosModules.iocService = {config, ...}: {
+        services.iocs.myIoc = {
+          description = "An optional description of your IOC";
+          package = self.packages.x86_64-linux.default;
+          # Directory where to find the 'st.cmd' file
+          workingDirectory = "iocBoot/iocMyIoc";
+        };
       };
     };
 }


### PR DESCRIPTION
Creates a NixOS module for declaring IOC services. It's based on `systemd.services`, but automatically configures `procServ` and some security isolation options.

The existing documentation and NixOS test are still using the old system, I'll update them in a subsequent PR.