### PR TITLE
Fix Phoebus alarm test flakiness

### DIFF
--- a/nixos/tests/phoebus/alarm.nix
+++ b/nixos/tests/phoebus/alarm.nix
@@ -84,6 +84,9 @@
       services.elasticsearch = {
         enable = true;
         package = pkgs.elasticsearch7;
+        extraConf = ''
+          xpack.security.enabled: false
+        '';
       };
 
       nixpkgs.config.allowUnfreePredicate = pkg:

--- a/nixos/tests/phoebus/alarm.py
+++ b/nixos/tests/phoebus/alarm.py
@@ -49,7 +49,7 @@ def get_alarm() -> dict[str, Any]:
 
 
 def get_logger(uri: str):
-    result_s = client.succeed(f"curl 'http://server:8082{uri}'")
+    result_s = client.succeed(f"curl -sSf 'http://server:8082{uri}'")
     return json.loads(result_s)
 
 

--- a/nixos/tests/phoebus/alarm.py
+++ b/nixos/tests/phoebus/alarm.py
@@ -186,19 +186,28 @@ with subtest("The data is still here after a server reboot"):
 
     wait_for_boot()
 
-    alarm = get_alarm()
-    assert alarm["current_severity"] == "OK"
-    assert alarm["severity"] == "OK"
+    with subtest("Phoebus alarm server data still coherent after reboot"):
+        alarm = get_alarm()
+        assert alarm["current_severity"] == "OK"
+        assert alarm["severity"] == "OK"
 
-    logger_alarms = get_logger("/search/alarm/pv/ALARM_TEST")
-    logger_alarms.sort(key=lambda event: event.get("time", ""), reverse=True)
-    alarm_states = [
-        alarm for alarm in logger_alarms if alarm["config"].startswith("state:")
-    ]
+    def test_reboot_data(_):
+        logger_alarms = get_logger("/search/alarm/pv/ALARM_TEST")
+        logger_alarms.sort(key=lambda event: event.get("time", ""), reverse=True)
+        alarm_states = [
+            alarm for alarm in logger_alarms if alarm["config"].startswith("state:")
+        ]
 
-    assert alarm_states[2]["current_severity"] == "MAJOR"
-    assert alarm_states[2]["severity"] == "MAJOR"
-    assert alarm_states[2]["value"] == "4.0"
+        if len(alarm_states) < 2:
+            return False
+
+        assert alarm_states[2]["current_severity"] == "MAJOR"
+        assert alarm_states[2]["severity"] == "MAJOR"
+        assert alarm_states[2]["value"] == "4.0"
+        return True
+
+    with subtest("Phoebus alarm logger data still coherent after reboot"):
+        retry(test_reboot_data)
 
 with subtest("Can export alarm configuration"):
     server.succeed(

--- a/nixos/tests/phoebus/alarm.py
+++ b/nixos/tests/phoebus/alarm.py
@@ -19,6 +19,13 @@ def wait_for_boot():
 
         client.wait_for_unit("multi-user.target")
 
+    with subtest("Elasticsearch cluster is healthy"):
+        print(
+            server.succeed(
+                "curl -sSf http://localhost:9200/_cluster/health?wait_for_status=green&timeout=60s"
+            )
+        )
+
     with subtest("Alarm logger is connected to Elasticsearch"):
         status = get_logger("/")
         assert status["elastic"]["status"] == "Connected"


### PR DESCRIPTION
It appears that the check for the data still there after reboot was too soon, leading to a test that would fail quite regularly, but not always.