### PR TITLE
docs: remove mentions of epics-base's Launchpad repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ This doesn't cause much issues: since EPNix is a Git repository, you use a fixed
 
 ### The epics-base package
 
-The epics-base package has no significant modification compared to the upstream version at [Launchpad].
+The epics-base package has no significant modification compared to the upstream version on [GitHub].
 One goal of EPNix is to have as little modification as possible, and upstream what's possible.
 
-  [Launchpad]: https://git.launchpad.net/epics-base
+  [GitHub]: https://github.com/epics-base/epics-base/
 
 ## Quick example of an EPNix configuration
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,10 +45,10 @@ However, since EPNix is a git repository, you will be able, through Nix, to use 
 The epics-base package
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The epics-base package has no significant modification compared to the upstream version at `Launchpad`_.
+The epics-base package has no significant modification compared to the upstream version on `GitHub`_.
 One goal of EPNix is to keep those modifications to a minimum, and upstream what’s possible.
 
-.. _Launchpad: https://git.launchpad.net/epics-base
+.. _GitHub: https://github.com/epics-base/epics-base/
 
 Release branches
 ~~~~~~~~~~~~~~~~

--- a/docs/ioc/index.rst
+++ b/docs/ioc/index.rst
@@ -38,7 +38,7 @@ Nix records this commit SHA in the ``flake.lock`` file, which should be checked 
 The epics-base package
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The epics-base package has no significant modification compared to the upstream version at `Launchpad`_.
+The epics-base package has no significant modification compared to the upstream version on `GitHub`_.
 One goal of EPNix is to keep those modifications to a minimum, and upstream what’s possible.
 
-.. _Launchpad: https://git.launchpad.net/epics-base
+.. _GitHub: https://github.com/epics-base/epics-base/


### PR DESCRIPTION
Use the more official GitHub repo, we're now using the GitHub as source for the build anyway, see #260