### PR TITLE
phoebus: 4.7.3 -> 5.0.0

### DIFF
--- a/docs/_vale/config/vocabularies/EPNix/accept.txt
+++ b/docs/_vale/config/vocabularies/EPNix/accept.txt
@@ -9,10 +9,13 @@ EPICS
 epics-base
 EPNix
 IOCs?
+LDAP
+LDIF
 nginx
 Nix
 NixOS
 NixOps
+OpenLDAP
 procServ
 RecCaster
 RecCeiver

--- a/docs/nixos-services/options-reference/phoebus-save-and-restore.md
+++ b/docs/nixos-services/options-reference/phoebus-save-and-restore.md
@@ -1,4 +1,8 @@
 # Phoebus save-and-restore
 
+List of NixOS options related to the Phoebus save-and-restore service.
+For how to use them,
+examine the {doc}`../user-guides/phoebus-save-and-restore` user guide.
+
 ```{nix:automodule} services.phoebus-save-and-restore
 ```

--- a/docs/nixos-services/user-guides/channel-finder.md
+++ b/docs/nixos-services/user-guides/channel-finder.md
@@ -124,13 +124,14 @@ This section assumes you already have a configured LDAP server.
 This configured LDAP server can be an embedded LDAP server of another service.
 
 If you want to use your company's LDAP server,
-contact your IT team for the LDAP configuration:
+ask your IT team for the LDAP configuration.
+The configuration must include:
 
 - URL,
 - base DN,
 - user DN pattern,
-- search base,
-- and search path.
+- group search base,
+- and group search path.
 
 Here is an example configuration:
 

--- a/docs/nixos-services/user-guides/phoebus-save-and-restore.md
+++ b/docs/nixos-services/user-guides/phoebus-save-and-restore.md
@@ -1,20 +1,20 @@
-# Phoebus Save-and-restore setup
+# Phoebus save-and-restore setup
 
-The Phoebus Save-and-restore service is used by clients
+The Phoebus save-and-restore service is used by clients
 to manage configuration and snapshots of PV values.
-These snapshots can then be used by clients for comparison or for restoring PVs.
+These snapshots can then be used by clients for comparison or for restoring process variables.
 
-This guide focuses on installing and configuring the Save-and-Restore service on a single server.
+This guide focuses on installing and configuring the save-and-restore service on a single server.
 
-For more details and documentation about Phoebus Save-and-Restore,
-you can examine the [Save-and-restore official documentation].
+For more details and documentation about Phoebus save-and-restore,
+you can examine the [save-and-restore official documentation].
 
 ```{include} ./pre-requisites.md
 ```
 
-## Enabling the Phoebus Save-and-restore service
+## Enabling the Phoebus save-and-restore service
 
-To enable the Phoebus Save-and-restore service,
+To enable the Phoebus save-and-restore service,
 add this to your configuration:
 
 ```{code-block} nix
@@ -24,6 +24,10 @@ add this to your configuration:
   services.phoebus-save-and-restore = {
     enable = true;
     openFirewall = true;
+
+    # Choose your authentication implementation
+    # see below for a list of available backends
+    settings."auth.impl" = "XXX";
   };
 
   # Phoebus save-and-restore needs ElasticSearch.
@@ -43,6 +47,11 @@ add this to your configuration:
 }
 ```
 
+:::{seealso}
+For a complete list of options related to Phoebus save-and-restore,
+see {nix:option}`services.phoebus-save-and-restore`.
+:::
+
 From the Phoebus graphical client side,
 add this configuration
 
@@ -50,12 +59,289 @@ add this configuration
 :caption: {file}`phoebus-client-settings.ini`
 
 # Replace the IP address with your server's IP address or domain name
-org.phoebus.applications.saveandrestore/jmasar.service.url=http://192.168.1.42:8080
+org.phoebus.applications.saveandrestore/jmasar.service.url=http://192.168.1.42:8080/save-restore
 ```
 
-:::{warning}
-URLs for future versions of Phoebus Save-and-restore will need to change to:
-`http://192.168.1.42:8080/save-restore`
+## Custom port
+
+To use a custom HTTP port,
+set the {nix:option}`services.phoebus-save-and-restore.settings."server.port"`.
+
+For example:
+
+```{code-block} nix
+:caption: {file}`phoebus-save-and-restore.nix` --- Set custom HTTP port
+
+{
+  services.phoebus-save-and-restore = {
+    enable = true;
+    openFirewall = true;
+
+    settings."server.port" = 1234;
+  };
+
+  # ...
+}
+```
+
+## Authentication
+
+Phoebus save-and-restore supports these authentication backends,
+which you can select
+by using the {nix:option}`services.phoebus-save-and-restore.settings."auth.impl"` option:
+
+Demo (`"demo"`)
+:   *Not recommended for production servers*.
+    Hard coded users and passwords.
+    Provides 3 users:
+
+    -   an admin
+    -   a read-only user
+    -   a normal user
+
+Embedded LDAP (`"ldap_embedded"`)
+:   At the start of the Phoebus save-and-restore service,
+    it starts an embedded LDAP server.
+
+LDAP (`"ldap"`)
+:   For a usage with an external LDAP server.
+
+Microsoft Active Directory (`"ad"`)
+:   For a usage with an external Microsoft Active Directory server.
+
+### Demo authentication
+
+:::{caution}
+This authentication type isn't recommended for production servers.
 :::
 
-[save-and-restore official documentation]: https://control-system-studio.readthedocs.io/en/latest/services/save-and-restore/doc/index.html
+This authentication lets you configure 3 users
+and their passwords
+in plain text in the configuration.
+
+Here are the settings that are used,
+and their default values:
+
+```{code-block} nix
+:caption: {file}`phoebus-save-and-restore.nix` --- Default values for demo authentication
+
+{
+  services.phoebus-save-and-restore = {
+    enable = true;
+    # ...
+
+    settings = {
+      "auth.impl" = "demo";
+
+      "demo.admin" = "admin";
+      "demo.admin.password" = "adminPass";
+      "demo.readOnly" = "johndoe";
+      "demo.readOnly.password" = "1234";
+      "demo.user" = "user";
+      "demo.user.password" = "userPass";
+    };
+  };
+
+  # ...
+}
+```
+
+### Embedded LDAP authentication
+
+:::{caution}
+Currently Phoebus doesn't support encrypted passwords in LDIF files.
+This means that password are stored in plain text
+in your Git repositories,
+and in the world-readable Nix store.
+
+If this isn't acceptable,
+setup and use an external LDAP or AD server.
+:::
+
+
+With this authentication backend,
+Phoebus save-and-restore starts an embedded LDAP server,
+which you can configure
+by using the {nix:option}`services.phoebus-save-and-restore.settings."spring.ldap.embedded.ldif"` option.
+
+This option must point to an [LDIF] file,
+that has the content of the LDAP database.
+
+This file must define two groups: `sar-user` and `sar-admin`.
+For more information about these roles,
+see [Phoebus save-and-restore's Authentication and Authorization] documentation.
+
+Start by downloading the [{file}`sar.ldif`] file from the Phoebus source code,
+put it next to your {file}`phoebus-save-and-restore.nix` file,
+and edit it to suit your needs.
+
+Configure Phoebus save-and-restore to use your LDIF file:
+
+```{code-block} nix
+:caption: {file}`phoebus-save-and-restore.nix` --- Configure the embedded LDAP authentication
+
+{
+  services.phoebus-save-and-restore = {
+    enable = true;
+    # ...
+
+    settings = {
+      "auth.impl" = "ldap_embedded";
+      "spring.ldap.embedded.ldif" = "file://${./sar.ldif}";
+    };
+  };
+
+  # ...
+}
+```
+
+#### Changing a user name
+
+To change a user name,
+set its "user ID" (`uid`)
+and "common name" (`cn`):
+
+```{code-block} ldif
+:caption: {file}`sar.ldif` --- Changing a user name
+:emphasize-lines: 3-4, 8
+:name: user-name-change
+
+# ...
+
+dn: uid=custom-user,ou=Group,dc=sar,dc=local
+uid: custom-user
+objectClass: account
+objectClass: posixAccount
+description: User with sar-user role
+cn: custom-user
+userPassword: XXX
+uidNumber: 23004
+gidNumber: 23004
+homeDirectory: /dev/null
+
+# ...
+```
+
+:::{important}
+Make sure to replace every `memberUid:` line that referenced the old user name.
+:::
+
+#### Setting a user password
+
+To set an plain text password,
+set the `userPassword` field:
+
+```{code-block} ldif
+:caption: {file}`sar.ldif` --- Changing a user password
+:emphasize-lines: 9
+
+# ...
+
+dn: uid=custom-user,ou=Group,dc=sar,dc=local
+uid: custom-user
+objectClass: account
+objectClass: posixAccount
+description: User with sar-user role
+cn: custom-user
+userPassword: my-custom-user-password
+uidNumber: 23004
+gidNumber: 23004
+homeDirectory: /dev/null
+
+# ...
+```
+
+#### Creating a new user
+
+To create a new user,
+copy and paste a block that has the `posixAccount` class,
+such as the one presented in {ref}`user-name-change`.
+
+Make sure that its `uidNumber` and `gidNumber` are unique.
+
+#### Adding a user to a group
+
+To add a user to a group:
+
+1.  go to the block that defines the group,
+
+    :::{hint}
+    The block must have the `posixGroup` class,
+    and should be named `sar-user` or `sar-admin`.
+    :::
+
+2.  and add a `memberUid:` line with your user name.
+
+For example,
+to add the user "custom-user" to the group "sar-user":
+
+```{code-block} ldif
+:caption: {file}`sar.ldif` --- Adding "custom-user" to the group "sar-user"
+:emphasize-lines: 10
+
+# ...
+
+dn: cn=sar-user,ou=Group,dc=sar,dc=local
+cn: sar-user
+objectClass: posixGroup
+description: save-n-restore user
+gidNumber: 27001
+uidNumber: 27001
+memberUid: user
+memberUid: custom-user
+
+# ...
+```
+
+### External LDAP authentication
+
+:::{note}
+Configuring an fully featured LDAP server is out of scope for this guide.
+See the [OpenLDAP NixOS Wiki page]
+for how to configure an OpenLDAP server
+on NixOS.
+:::
+
+This section assumes you already have a configured LDAP server.
+This configured LDAP server can be an embedded LDAP server of another service.
+
+If you want to use your company's LDAP server,
+ask your IT team for the LDAP configuration.
+The configuration must include:
+
+- URL,
+- base DN,
+- user DN pattern,
+- group search base,
+- and group search path.
+
+Here is an example configuration:
+
+```{code-block} nix
+:caption: {file}`phoebus-save-and-restore.nix` --- Configure the external LDAP authentication
+
+{
+  services.phoebus-save-and-restore = {
+    enable = true;
+    # ...
+
+    settings = {
+      "auth.impl" = "ldap";
+
+      "ldap.urls" = "ldaps://auth.mycompany.com/dc=mycompany,dc=com";
+      "ldap.base.dn" = "dc=mycompany,dc=com";
+      "ldap.user.dn.pattern" = "uid={0},ou=People";
+      "ldap.groups.search.base" = "ou=Group";
+      "ldap.groups.search.pattern" = "(memberUid= {1})";
+    };
+  };
+
+  # ...
+}
+```
+
+  [Phoebus save-and-restore's Authentication and Authorization]: https://control-system-studio.readthedocs.io/en/latest/services/save-and-restore/doc/index.html#authentication-and-authorization
+  [{file}`sar.ldif`]: https://github.com/ControlSystemStudio/phoebus/blob/master/services/save-and-restore/src/main/resources/sar.ldif
+  [LDIF]: https://en.wikipedia.org/wiki/LDAP_Data_Interchange_Format
+  [OpenLDAP NixOS Wiki page]: https://wiki.nixos.org/wiki/OpenLDAP
+  [save-and-restore official documentation]: https://control-system-studio.readthedocs.io/en/latest/services/save-and-restore/doc/index.html

--- a/docs/release-notes/2505.md
+++ b/docs/release-notes/2505.md
@@ -19,6 +19,27 @@
   and will be removed in version `nixos-26.05`.
   Please follow the migration guide {doc}`../ioc/user-guides/deprecations/migrating-from-modules-development`.
 
+### Phoebus
+
+Phoebus was upgraded from 4.7.x to 5.0.x,
+which contains breaking changes:
+
+- The Phoebus client settings are now not persisted on disk.
+  This means that for custom settings,
+  either:
+
+  - you must always start Phoebus with the `-settings /path/to/settings.ini` option,
+  - or you must configure the `settings.ini` file using an EPNix NixOS module (TODO),
+  - or you must place the `settings.ini` file in a default location.
+    See the [Phoebus Preference Settings] documentation for more information.
+
+- Phoebus save-and-restore now requires authentication
+  for all non read-only operations.
+  This means that the new option {nix:option}`services.phoebus-save-and-restore.settings."auth.impl"`
+  is now required.
+  Examine the updated guide {doc}`../nixos-services/user-guides/phoebus-save-and-restore`
+  for how to use it.
+
 ## Highlights
 
 - Archiver Appliance was upgrade from 1.1.0 -> 2.0.5,
@@ -27,3 +48,4 @@
   {option}`services.archiver-appliance` NixOS options.
 
 [archiver appliance 2.0.5 release notes]: https://github.com/archiver-appliance/epicsarchiverap/releases/tag/2.0.5
+[Phoebus Preference Settings]: https://control-system-studio.readthedocs.io/en/latest/preferences.html

--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -57,18 +57,16 @@ in {
             apply = lib.concatStringsSep ",";
           };
 
-          es_host = lib.mkOption {
-            description = "Elasticsearch server host";
-            type = lib.types.str;
-            default = "localhost";
-          };
+          es_urls = lib.mkOption {
+            description = ''
+              List of Elasticsearch node URLs.
 
-          es_port = lib.mkOption {
-            description = "Elasticsearch server port";
-            type = lib.types.port;
-            default = config.services.elasticsearch.port;
-            defaultText = lib.literalExpression "config.services.elasticsearch.port";
-            apply = toString;
+              All nodes must belong to the same cluster.
+            '';
+            type = with lib.types; listOf str;
+            default = ["http://localhost:${toString config.services.elasticsearch.port}"];
+            defaultText = lib.literalExpression ''[ "http://localhost:''${toString config.services.elasticsearch.port}" ]'';
+            apply = lib.concatStringsSep ",";
           };
 
           es_sniff = lib.mkOption {

--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -37,7 +37,7 @@ in {
         Note that options containing a "." must be quoted.
 
         Available options can be seen here:
-        <https://github.com/ControlSystemStudio/phoebus/blob/master/services/alarm-logger/src/main/resources/application.properties>
+        <https://github.com/ControlSystemStudio/phoebus/blob/v${pkgs.epnix.phoebus-alarm-logger.version}/services/alarm-logger/src/main/resources/application.properties>
       '';
       default = {};
       type = lib.types.submodule {

--- a/nixos/modules/phoebus/save-and-restore.nix
+++ b/nixos/modules/phoebus/save-and-restore.nix
@@ -39,7 +39,7 @@ in {
         Note that options containing a "." must be quoted.
 
         Available options can be seen here:
-        <https://github.com/ControlSystemStudio/phoebus/blob/master/services/save-and-restore/src/main/resources/application.properties>
+        <https://github.com/ControlSystemStudio/phoebus/blob/v${pkgs.epnix.phoebus-save-and-restore.version}/services/save-and-restore/src/main/resources/application.properties>
       '';
       default = {};
       type = lib.types.submodule {
@@ -50,6 +50,114 @@ in {
             type = lib.types.port;
             default = 8080;
             apply = toString;
+          };
+
+          "auth.impl" = lib.mkOption {
+            description = ''
+              Authentication implementation.
+
+              Supported options:
+
+              `"ad"`
+              :   Microsoft Active Directory
+
+              `"ldap"`
+              :   LDAP
+
+              `"ldap_embedded"`
+              :   Embedded LDAP. Config in sar.ldif
+
+              `"demo"`
+              :   Hard coded users and passwords.
+                  Provides 3 users:
+
+                  -   an admin
+                  -   a read-only user
+                  -   a normal user
+
+                  See the following options:
+
+                  -   {nix:option}`"demo.admin"`
+                  -   {nix:option}`"demo.admin.password"`
+                  -   {nix:option}`"demo.readOnly"`
+                  -   {nix:option}`"demo.readOnly.password"`
+                  -   {nix:option}`"demo.user"`
+                  -   {nix:option}`"demo.user.password"`
+            '';
+            type = lib.types.enum ["ad" "ldap" "ldap_embedded" "demo"];
+          };
+
+          "demo.user" = lib.mkOption {
+            description = ''
+              Username for the normal demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "user";
+          };
+
+          "demo.user.password" = lib.mkOption {
+            description = ''
+              Password for the normal demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "userPass";
+          };
+
+          "demo.admin" = lib.mkOption {
+            description = ''
+              Username for the admin demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "admin";
+          };
+
+          "demo.admin.password" = lib.mkOption {
+            description = ''
+              Password for the admin demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "adminPass";
+          };
+
+          "demo.readOnly" = lib.mkOption {
+            description = ''
+              Username for the normal demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "johndoe";
+          };
+
+          "demo.readOnly.password" = lib.mkOption {
+            description = ''
+              Password for the read-only demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "1234";
+          };
+
+          "spring.ldap.embedded.ldif" = lib.mkOption {
+            description = ''
+              Path to [LDIF] file describing the content of the embedded LDAP server.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"embedded_ldap"`.
+
+                [LDIF]: https://en.wikipedia.org/wiki/LDAP_Data_Interchange_Format
+            '';
+            type = lib.types.str;
+            default = "classpath:sar.ldif";
+            example = lib.literalExpression ''"file://''${./sar.ldif}"'';
           };
 
           "elasticsearch.network.host" = lib.mkOption {

--- a/nixos/tests/phoebus/alarm.py
+++ b/nixos/tests/phoebus/alarm.py
@@ -188,8 +188,8 @@ with subtest("The data is still here after a server reboot"):
 
     with subtest("Phoebus alarm server data still coherent after reboot"):
         alarm = get_alarm()
-        assert alarm["current_severity"] == "OK"
-        assert alarm["severity"] == "OK"
+        assert alarm["current_severity"] == "OK", "wrong current severity"
+        assert alarm["severity"] == "OK", "wrong severity"
 
     def test_reboot_data(_):
         logger_alarms = get_logger("/search/alarm/pv/ALARM_TEST")
@@ -201,9 +201,9 @@ with subtest("The data is still here after a server reboot"):
         if len(alarm_states) < 2:
             return False
 
-        assert alarm_states[2]["current_severity"] == "MAJOR"
-        assert alarm_states[2]["severity"] == "MAJOR"
-        assert alarm_states[2]["value"] == "4.0"
+        assert alarm_states[-3]["current_severity"] == "MAJOR", "wrong current severity"
+        assert alarm_states[-3]["severity"] == "MAJOR", "wrong severity"
+        assert alarm_states[-3]["value"] == "4.0", "wrong value"
         return True
 
     with subtest("Phoebus alarm logger data still coherent after reboot"):

--- a/nixos/tests/phoebus/save-and-restore.ldif
+++ b/nixos/tests/phoebus/save-and-restore.ldif
@@ -1,0 +1,77 @@
+dn: dc=sar,dc=local
+objectClass: dcObject
+objectClass: organization
+dc: sar
+o: sar
+
+dn: cn=sar,dc=sar,dc=local
+objectClass: simpleSecurityObject
+objectClass: organizationalRole
+userPassword:: e1NIQX1jUkR0cE5DZUJpcWw1S09Rc0tWeXJBMHNBaUE9
+cn: sar
+
+dn: ou=Group,dc=sar,dc=local
+objectClass: organizationalunit
+ou: Group
+description: groups branch
+
+dn: cn=sar-user,ou=Group,dc=sar,dc=local
+cn: sar-user
+objectClass: posixGroup
+description: save-n-restore user
+gidNumber: 27001
+uidNumber: 27001
+memberUid: user
+
+dn: cn=sar-admin,ou=Group,dc=sar,dc=local
+cn: sar-admin
+objectClass: posixGroup
+description: save-n-restore admin
+gidNumber: 27003
+uidNumber: 27003
+memberUid: admin
+memberUid: customAdmin
+
+dn: uid=user,ou=Group,dc=sar,dc=local
+uid: user
+objectClass: account
+objectClass: posixAccount
+description: User with sar-user role
+cn: user
+userPassword: userPass
+uidNumber: 23004
+gidNumber: 23004
+homeDirectory: /dev/null
+
+dn: uid=johndoe,ou=Group,dc=sar,dc=local
+uid: johndoe
+objectClass: account
+objectClass: posixAccount
+description: User without sar roles
+cn: johndoe
+userPassword: 1234
+uidNumber: 23007
+gidNumber: 23007
+homeDirectory: /dev/null
+
+dn: uid=admin,ou=Group,dc=sar,dc=local
+uid: admin
+objectClass: account
+objectClass: posixAccount
+description: User with admin role
+cn: admin
+userPassword: adminPass
+uidNumber: 23005
+gidNumber: 23005
+homeDirectory: /dev/null
+
+dn: uid=customAdmin,ou=Group,dc=sar,dc=local
+uid: customAdmin
+objectClass: account
+objectClass: posixAccount
+description: Custom user with admin role
+cn: customAdmin
+userPassword: customAdminPass
+uidNumber: 23006
+gidNumber: 23006
+homeDirectory: /dev/null

--- a/nixos/tests/phoebus/save-and-restore.nix
+++ b/nixos/tests/phoebus/save-and-restore.nix
@@ -11,6 +11,11 @@
       services.phoebus-save-and-restore = {
         enable = true;
         openFirewall = true;
+
+        settings = {
+          "auth.impl" = "ldap_embedded";
+          "spring.ldap.embedded.ldif" = "file://${./save-and-restore.ldif}";
+        };
       };
 
       services.elasticsearch = {

--- a/nixos/tests/phoebus/save-and-restore.py
+++ b/nixos/tests/phoebus/save-and-restore.py
@@ -25,6 +25,7 @@ def put(uri: str, data: JSON):
         client.succeed(
             "curl -sSf "
             "-X PUT "
+            "-u customAdmin:customAdminPass "
             "-H 'Content-Type: application/json' "
             "-H 'Accept: application/json' "
             f"'{base_url}{uri}' "
@@ -37,6 +38,7 @@ def delete(uri: str):
     client.succeed(
         "curl -sSf "
         "-X DELETE "
+        "-u customAdmin:customAdminPass "
         "-H 'Content-Type: application/json' "
         "-H 'Accept: application/json' "
         f"'{base_url}{uri}'"
@@ -60,6 +62,7 @@ with subtest("We can create a subnode"):
     result = put(
         f"/node?parentNodeId={root_node_id}",
         {
+            "nodeType": "FOLDER",
             "name": "subnode",
             "description": "A test subnode",
             "userName": user,
@@ -79,6 +82,7 @@ with subtest("We can create a config"):
         {
             "configurationNode": {
                 "name": "test configuration",
+                "nodeType": "CONFIGURATION",
                 "userName": user,
             },
             "configurationData": {
@@ -145,6 +149,7 @@ with subtest("We can create a snapshot"):
         {
             "snapshotNode": {
                 "name": "test snapshot",
+                "nodeType": "SNAPSHOT",
                 "userName": user,
             },
             "snapshotData": {

--- a/pkgs/epnix/tools/phoebus/deps/default.nix
+++ b/pkgs/epnix/tools/phoebus/deps/default.nix
@@ -8,13 +8,13 @@
 }:
 stdenv.mkDerivation {
   pname = "phoebus-deps";
-  version = "4.7.3";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "ControlSystemStudio";
     repo = "phoebus";
-    rev = "v4.7.3";
-    hash = "sha256-1Q66iZ+mTXzQ9pjW5wypG7q7rPy9K+PUcQXsKKk2sNo=";
+    rev = "v5.0.0";
+    hash = "sha256-Ig5l3WlO6cqJ9Xpo1DwpKLbAeZlCOFYCID4S1fsaCmA=";
   };
 
   nativeBuildInputs = [jdk maven];
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "sha256-WPTw40NQQclYE3z283yVmd5epP01R0oMsI+1UuADGB4=";
+  outputHash = "sha256-YQsL1EbqyDHtlqXm4C3NmMpqq6LDZzhhjtQfwcB6yfs=";
 
   doCheck = false;
 


### PR DESCRIPTION
- [x] figure out why the save-and-restore test fail, and add documentation if the failure comes from a breaking change
- [x] skim through the release notes, to figure out breaking changes
- [x] document breaking changes in EPNix's release notes
- [x] update existing Phoebus services documentation if necessary

This Phoebus release includes the "In-memory preferences" contribution, which will enable us to have a Phoebus settings module (#38), to be done in another PR.