### PR TITLE
Nixos 24.11 phoebus 4.7.4

### DIFF
--- a/docs/_vale/config/vocabularies/EPNix/accept.txt
+++ b/docs/_vale/config/vocabularies/EPNix/accept.txt
@@ -8,10 +8,13 @@ EPICS
 epics-base
 EPNix
 IOCs?
+LDAP
+LDIF
 nginx
 Nix
 NixOS
 NixOps
+OpenLDAP
 procServ
 SELinux
 StreamDevice

--- a/docs/nixos-services/options-reference/phoebus-save-and-restore.md
+++ b/docs/nixos-services/options-reference/phoebus-save-and-restore.md
@@ -1,0 +1,8 @@
+# Phoebus save-and-restore
+
+List of NixOS options related to the Phoebus save-and-restore service.
+For how to use them,
+examine the {doc}`../user-guides/phoebus-save-and-restore` user guide.
+
+```{nix:automodule} services.phoebus-save-and-restore
+```

--- a/docs/nixos-services/user-guides/channel-finder.md
+++ b/docs/nixos-services/user-guides/channel-finder.md
@@ -1,0 +1,332 @@
+# ChannelFinder service setup
+
+ChannelFinder is a directory service which enables searching for PV names,
+called *channels names*,
+and associated metadata.
+
+A ChannelFinder server is usually combined with a "RecCaster" module in the IOC,
+that sends the metadata,
+and a "RecCeiver" server
+that scans and retrieves the metadata from "RecCaster."
+
+For more information on the ChannelFinder architecture,
+see the official [ChannelFinder introduction].
+
+```{include} ./pre-requisites.md
+```
+
+## ChannelFinder service
+
+To enable the ChannelFinder service,
+use {nix:option}`services.channel-finder.enable` and related options.
+You will also need to enable ElasticSearch.
+
+For example:
+
+```{code-block} nix
+:caption: {file}`channel-finder.nix` --- ChannelFinder configuration example
+
+{lib, pkgs, ...}: {
+  services.channel-finder = {
+    enable = true;
+    openFirewall = true;
+    settings = {
+
+      # Choose your authentication type (see below for explanations)
+      # ---
+      #"demo_auth.enabled" = true;
+      #"ldap.enabled" = true;
+
+      "server.port" = 8444;
+      "server.http.port" = 8082;
+    };
+  };
+
+  # Install Elasticsearch,
+  # because it's a ChannelFinder service dependency
+  services.elasticsearch = {
+    enable = true;
+    package = pkgs.elasticsearch7;
+  };
+
+  # Elasticsearch, needed by ChannelFinder, is not free software (SSPL | Elastic License).
+  # To accept the license, add the code below:
+  nixpkgs.config.allowUnfreePredicate = pkg:
+    builtins.elem (lib.getName pkg) [
+      "elasticsearch"
+    ];
+}
+```
+
+This configuration starts the ChannelFinder service on port 8082.
+You can open your browser at <http://localhost:8082/> to see the ChannelFinder admin page.
+
+For more settings,
+examine the [ChannelFinder configuration] reference
+and the {nix:option}`services.channel-finder.settings` option.
+
+### Authentication
+
+ChannelFinder supports different types of authentication backends:
+
+Demo authentication
+
+: *Not recommended for production servers*.
+  Users,
+  their roles,
+  and passwords
+  are specified in the configuration file,
+  in plain text.
+
+External LDAP server
+
+: The ChannelFinder service connects to an external LDAP server,
+  and uses it for authentication and role assignment.
+
+  :::{note}
+  Configuring an fully-featured LDAP server is out of scope for this guide,
+  but the ChannelFinder service can connect to another service's embedded LDAP server.
+
+  For example,
+  ChannelFinder could connect to a Phoebus Olog's embedded LDAP server configured beforehand.
+  :::
+
+#### Demo authentication
+
+:::{caution}
+This authentication type is not recommended for production servers.
+:::
+
+Users,
+roles,
+and passwords
+are stored as comma-separated list in the configuration.
+
+For example:
+
+```{code-block} nix
+:caption: {file}`channel-finder.nix` --- demo authentication example
+
+services.channel-finder = {
+  settings = {
+    "demo_auth.enabled" = true;
+    "demo_auth.users" = "admin,operator,expert";
+    "demo_auth.pwd" = "adminPass,operatorPass,expertPass";
+    # Multiple roles can be given by separating them with ':'
+    "demo_auth.roles" = "ADMIN:EXPERT,USER,USER:EXPERT";
+  };
+};
+```
+
+#### External LDAP server
+
+This section assumes you already have a configured LDAP server.
+This configured LDAP server can be an embedded LDAP server of another service.
+
+If you want to use your company's LDAP server,
+ask your IT team for the LDAP configuration.
+The configuration must include:
+
+- URL,
+- base DN,
+- user DN pattern,
+- group search base,
+- and group search path.
+
+Here is an example configuration:
+
+```{code-block} nix
+:caption: {file}`channel-finder.nix` --- external LDAP authentication example
+
+services.channel-finder = {
+  settings = {
+    "ldap.enabled" = true;
+    "ldap.urls" = "ldaps://auth.mycompany.com/dc=mycompany,dc=com";
+    "ldap.user.dn.pattern" = "uid={0},ou=People,dc=mycompany,dc=com";
+    "ldap.groups.search.base" = "ou=Group,dc=mycompany,dc=com";
+    "ldap.groups.search.pattern" = "(memberUid= {1})";
+  };
+};
+```
+
+## RecCeiver
+
+The RecCeiver service scans for IOCs in the network,
+and fetches the list of PV names and other metadata.
+You can configure it to put this information into the ChannelFinder service.
+
+Use the `channelfinderapi.DEFAULT` setting for configuring the connection to the ChannelFinder service,
+and use the `settings` option for configuring all other settings.
+
+For a list of available `settings`,
+examine the [RecCeiver demo.conf] file.
+
+Also examine the {nix:option}`services.recceiver.channelfinderapi`
+and {nix:option}`services.recceiver.settings` options.
+
+TODO: explain which cf role is needed
+
+For example:
+
+```{code-block} nix
+:caption: {file}`channel-finder.nix` --- RecCeiver configuration example
+:name: recceiver-configuration-example
+
+{lib, pkgs, ...}: {
+  # Other previous options...
+
+  services.recceiver = {
+    enable = true;
+
+    channelfinderapi.DEFAULT = {
+      username = "admin";
+      password = "adminPass";
+    };
+
+    settings = {
+      recceiver = {
+        # Necessary if you want a firewall,
+        # which is enabled by default in NixOS.
+        bind = "0.0.0.0:5050";
+
+        # When receiving metadata,
+        # print it on the command-line (show),
+        # and send it to ChannelFinder (cf).
+        procs = ["show" "cf"];
+      };
+      cf = {
+        # PV metadata to send to ChannelFinder
+        alias = "on";
+        recordDesc = "on";
+        recordType = "on";
+      };
+    };
+  };
+
+  networking.firewall.allowedTCPPorts = [5050];
+}
+```
+
+(recceiver-firewall)=
+### Firewall
+
+If `settings.bind` is unset,
+RecCeiver listens on a random port,
+which makes it difficult to open the firewall.
+
+To open the firewall,
+make sure to set the bind address to a fixed port,
+and open it in the firewall as TCP,
+as shown in the {ref}`recceiver-configuration-example`.
+
+On the IOC side,
+the firewall needs to allow the UDP announcer port,
+which by default is 5049.
+
+If your IOC is a NixOS machine,
+you can open the firewall with this configuration:
+
+```{code-block} nix
+:caption: Opening the IOC's firewall for RecCaster
+
+networking.firewall.allowedUDPPorts = [5049];
+```
+
+### Setting the address list
+
+If you want to scan a specific network,
+or if you want to change the port number used for scanning,
+you can use the `settings.recceiver.addrlist` option.
+
+:::{warning}
+If you change the port,
+make sure to also change it in the IOC firewall rules.
+
+See {ref}`recceiver-firewall`.
+:::
+
+```{code-block} nix
+:caption: {file}`channel-finder.nix` --- changing the RecCeiver address list
+
+{lib, pkgs, ...}: {
+  # ...
+
+  services.recceiver = {
+    # ...
+    settings = {
+      recceiver = {
+        # ...
+
+        # If you change the port,
+        # make sure to also change it in the IOC firewall rules
+        addrlist = ["192.168.1.255:5049"];
+      };
+      # ...
+    };
+  };
+
+  # ...
+}
+```
+
+(recceiver-custom-metadata)=
+### Custom metadata
+
+To add custom metadata variable to the ChannelFinder service,
+use the `settings.cf.environment_vars` option,
+for example:
+
+```{code-block} nix
+:caption: {file}`channel-finder.nix` --- adding custom metadata to ChannelFinder
+
+{lib, pkgs, ...}: {
+  # ...
+
+  services.recceiver = {
+    # ...
+    settings = {
+      # ...
+      cf = {
+        # ...
+        environment_vars = {
+          # Follows the pattern:
+          # IOC_VARIABLE = "ChannelFinderProperty";
+          CONTACT = "Concact";
+          EPICS_BASE = "EpicsBase";
+          EPICS_VERSION = "EpicsVersion";
+          PWD = "WorkingDirectory";
+        };
+      };
+    };
+  };
+};
+```
+
+### External ChannelFinder server
+
+If your ChannelFinder server is located on another machine,
+use the `channelfinderapi.DEFAULT.BaseURL` option:
+
+```{code-block} nix
+:caption: {file}`channel-finder.nix` --- specifying an external ChannelFinder server
+
+  services.recceiver = {
+    # ...
+
+    channelfinderapi.DEFAULT = {
+      BaseURL = "http://192.168.1.42:8082/ChannelFinder";
+      # ...
+    };
+
+    # ...
+  };
+```
+
+## RecCaster
+
+To configure RecCaster in your IOCs,
+examine the guide {doc}`../../ioc/user-guides/reccaster`.
+
+[channelfinder configuration]: https://channelfinder.readthedocs.io/en/latest/config.html
+[channelfinder introduction]: https://channelfinder.readthedocs.io/en/latest/overview.html
+[recceiver demo.conf]: https://github.com/ChannelFinder/recsync/blob/1.6/server/demo.conf

--- a/docs/nixos-services/user-guides/phoebus-save-and-restore.md
+++ b/docs/nixos-services/user-guides/phoebus-save-and-restore.md
@@ -1,0 +1,347 @@
+# Phoebus save-and-restore setup
+
+The Phoebus save-and-restore service is used by clients
+to manage configuration and snapshots of PV values.
+These snapshots can then be used by clients for comparison or for restoring process variables.
+
+This guide focuses on installing and configuring the save-and-restore service on a single server.
+
+For more details and documentation about Phoebus save-and-restore,
+you can examine the [save-and-restore official documentation].
+
+```{include} ./pre-requisites.md
+```
+
+## Enabling the Phoebus save-and-restore service
+
+To enable the Phoebus save-and-restore service,
+add this to your configuration:
+
+```{code-block} nix
+:caption: {file}`phoebus-save-and-restore.nix`
+
+{lib, ...}: {
+  services.phoebus-save-and-restore = {
+    enable = true;
+    openFirewall = true;
+
+    # Choose your authentication implementation
+    # see below for a list of available backends
+    settings."auth.impl" = "XXX";
+  };
+
+  # Phoebus save-and-restore needs ElasticSearch.
+  # If not already enabled elsewhere in your configuration,
+  # Enable it with the code below:
+  services.elasticsearch = {
+    enable = true;
+    package = pkgs.elasticsearch7;
+  };
+
+  # Elasticsearch, needed by Phoebus Save-and-restore, is not free software (SSPL | Elastic License).
+  # To accept the license, add the code below:
+  nixpkgs.config.allowUnfreePredicate = pkg:
+    builtins.elem (lib.getName pkg) [
+      "elasticsearch"
+    ];
+}
+```
+
+:::{seealso}
+For a complete list of options related to Phoebus save-and-restore,
+see {nix:option}`services.phoebus-save-and-restore`.
+:::
+
+From the Phoebus graphical client side,
+add this configuration
+
+```{code-block} ini
+:caption: {file}`phoebus-client-settings.ini`
+
+# Replace the IP address with your server's IP address or domain name
+org.phoebus.applications.saveandrestore/jmasar.service.url=http://192.168.1.42:8080/save-restore
+```
+
+## Custom port
+
+To use a custom HTTP port,
+set the {nix:option}`services.phoebus-save-and-restore.settings."server.port"`.
+
+For example:
+
+```{code-block} nix
+:caption: {file}`phoebus-save-and-restore.nix` --- Set custom HTTP port
+
+{
+  services.phoebus-save-and-restore = {
+    enable = true;
+    openFirewall = true;
+
+    settings."server.port" = 1234;
+  };
+
+  # ...
+}
+```
+
+## Authentication
+
+Phoebus save-and-restore supports these authentication backends,
+which you can select
+by using the {nix:option}`services.phoebus-save-and-restore.settings."auth.impl"` option:
+
+Demo (`"demo"`)
+:   *Not recommended for production servers*.
+    Hard coded users and passwords.
+    Provides 3 users:
+
+    -   an admin
+    -   a read-only user
+    -   a normal user
+
+Embedded LDAP (`"ldap_embedded"`)
+:   At the start of the Phoebus save-and-restore service,
+    it starts an embedded LDAP server.
+
+LDAP (`"ldap"`)
+:   For a usage with an external LDAP server.
+
+Microsoft Active Directory (`"ad"`)
+:   For a usage with an external Microsoft Active Directory server.
+
+### Demo authentication
+
+:::{caution}
+This authentication type isn't recommended for production servers.
+:::
+
+This authentication lets you configure 3 users
+and their passwords
+in plain text in the configuration.
+
+Here are the settings that are used,
+and their default values:
+
+```{code-block} nix
+:caption: {file}`phoebus-save-and-restore.nix` --- Default values for demo authentication
+
+{
+  services.phoebus-save-and-restore = {
+    enable = true;
+    # ...
+
+    settings = {
+      "auth.impl" = "demo";
+
+      "demo.admin" = "admin";
+      "demo.admin.password" = "adminPass";
+      "demo.readOnly" = "johndoe";
+      "demo.readOnly.password" = "1234";
+      "demo.user" = "user";
+      "demo.user.password" = "userPass";
+    };
+  };
+
+  # ...
+}
+```
+
+### Embedded LDAP authentication
+
+:::{caution}
+Currently Phoebus doesn't support encrypted passwords in LDIF files.
+This means that password are stored in plain text
+in your Git repositories,
+and in the world-readable Nix store.
+
+If this isn't acceptable,
+setup and use an external LDAP or AD server.
+:::
+
+
+With this authentication backend,
+Phoebus save-and-restore starts an embedded LDAP server,
+which you can configure
+by using the {nix:option}`services.phoebus-save-and-restore.settings."spring.ldap.embedded.ldif"` option.
+
+This option must point to an [LDIF] file,
+that has the content of the LDAP database.
+
+This file must define two groups: `sar-user` and `sar-admin`.
+For more information about these roles,
+see [Phoebus save-and-restore's Authentication and Authorization] documentation.
+
+Start by downloading the [{file}`sar.ldif`] file from the Phoebus source code,
+put it next to your {file}`phoebus-save-and-restore.nix` file,
+and edit it to suit your needs.
+
+Configure Phoebus save-and-restore to use your LDIF file:
+
+```{code-block} nix
+:caption: {file}`phoebus-save-and-restore.nix` --- Configure the embedded LDAP authentication
+
+{
+  services.phoebus-save-and-restore = {
+    enable = true;
+    # ...
+
+    settings = {
+      "auth.impl" = "ldap_embedded";
+      "spring.ldap.embedded.ldif" = "file://${./sar.ldif}";
+    };
+  };
+
+  # ...
+}
+```
+
+#### Changing a user name
+
+To change a user name,
+set its "user ID" (`uid`)
+and "common name" (`cn`):
+
+```{code-block} ldif
+:caption: {file}`sar.ldif` --- Changing a user name
+:emphasize-lines: 3-4, 8
+:name: user-name-change
+
+# ...
+
+dn: uid=custom-user,ou=Group,dc=sar,dc=local
+uid: custom-user
+objectClass: account
+objectClass: posixAccount
+description: User with sar-user role
+cn: custom-user
+userPassword: XXX
+uidNumber: 23004
+gidNumber: 23004
+homeDirectory: /dev/null
+
+# ...
+```
+
+:::{important}
+Make sure to replace every `memberUid:` line that referenced the old user name.
+:::
+
+#### Setting a user password
+
+To set an plain text password,
+set the `userPassword` field:
+
+```{code-block} ldif
+:caption: {file}`sar.ldif` --- Changing a user password
+:emphasize-lines: 9
+
+# ...
+
+dn: uid=custom-user,ou=Group,dc=sar,dc=local
+uid: custom-user
+objectClass: account
+objectClass: posixAccount
+description: User with sar-user role
+cn: custom-user
+userPassword: my-custom-user-password
+uidNumber: 23004
+gidNumber: 23004
+homeDirectory: /dev/null
+
+# ...
+```
+
+#### Creating a new user
+
+To create a new user,
+copy and paste a block that has the `posixAccount` class,
+such as the one presented in {ref}`user-name-change`.
+
+Make sure that its `uidNumber` and `gidNumber` are unique.
+
+#### Adding a user to a group
+
+To add a user to a group:
+
+1.  go to the block that defines the group,
+
+    :::{hint}
+    The block must have the `posixGroup` class,
+    and should be named `sar-user` or `sar-admin`.
+    :::
+
+2.  and add a `memberUid:` line with your user name.
+
+For example,
+to add the user "custom-user" to the group "sar-user":
+
+```{code-block} ldif
+:caption: {file}`sar.ldif` --- Adding "custom-user" to the group "sar-user"
+:emphasize-lines: 10
+
+# ...
+
+dn: cn=sar-user,ou=Group,dc=sar,dc=local
+cn: sar-user
+objectClass: posixGroup
+description: save-n-restore user
+gidNumber: 27001
+uidNumber: 27001
+memberUid: user
+memberUid: custom-user
+
+# ...
+```
+
+### External LDAP authentication
+
+:::{note}
+Configuring an fully featured LDAP server is out of scope for this guide.
+See the [OpenLDAP NixOS Wiki page]
+for how to configure an OpenLDAP server
+on NixOS.
+:::
+
+This section assumes you already have a configured LDAP server.
+This configured LDAP server can be an embedded LDAP server of another service.
+
+If you want to use your company's LDAP server,
+ask your IT team for the LDAP configuration.
+The configuration must include:
+
+- URL,
+- base DN,
+- user DN pattern,
+- group search base,
+- and group search path.
+
+Here is an example configuration:
+
+```{code-block} nix
+:caption: {file}`phoebus-save-and-restore.nix` --- Configure the external LDAP authentication
+
+{
+  services.phoebus-save-and-restore = {
+    enable = true;
+    # ...
+
+    settings = {
+      "auth.impl" = "ldap";
+
+      "ldap.urls" = "ldaps://auth.mycompany.com/dc=mycompany,dc=com";
+      "ldap.base.dn" = "dc=mycompany,dc=com";
+      "ldap.user.dn.pattern" = "uid={0},ou=People";
+      "ldap.groups.search.base" = "ou=Group";
+      "ldap.groups.search.pattern" = "(memberUid= {1})";
+    };
+  };
+
+  # ...
+}
+```
+
+  [Phoebus save-and-restore's Authentication and Authorization]: https://control-system-studio.readthedocs.io/en/latest/services/save-and-restore/doc/index.html#authentication-and-authorization
+  [{file}`sar.ldif`]: https://github.com/ControlSystemStudio/phoebus/blob/master/services/save-and-restore/src/main/resources/sar.ldif
+  [LDIF]: https://en.wikipedia.org/wiki/LDAP_Data_Interchange_Format
+  [OpenLDAP NixOS Wiki page]: https://wiki.nixos.org/wiki/OpenLDAP
+  [save-and-restore official documentation]: https://control-system-studio.readthedocs.io/en/latest/services/save-and-restore/doc/index.html

--- a/docs/release-notes/2505.md
+++ b/docs/release-notes/2505.md
@@ -1,0 +1,51 @@
+# 25.05 Release notes
+
+```{default-domain} nix
+```
+
+## New features
+
+- New module {option}`services.iocs`
+  to deploy EPICS IOCs as systemd services.
+
+  If you deployed EPICS IOCs manually by using `systemd.services`,
+  or used the configuration {samp}`epnix.nixos.services.{ioc}.config`
+  generated from the now deprecated IOC module system,
+  read the {doc}`../nixos-services/user-guides/ioc-services` NixOS guide.
+
+## Breaking changes
+
+- The old way of developing IOCs was deprecated,
+  and will be removed in version `nixos-26.05`.
+  Please follow the migration guide {doc}`../ioc/user-guides/deprecations/migrating-from-modules-development`.
+
+### Phoebus
+
+Phoebus was upgraded from 4.7.x to 5.0.x,
+which contains breaking changes:
+
+- The Phoebus client settings are now not persisted on disk.
+  This means that for custom settings,
+  either:
+
+  - you must always start Phoebus with the `-settings /path/to/settings.ini` option,
+  - or you must configure the `settings.ini` file using an EPNix NixOS module (TODO),
+  - or you must place the `settings.ini` file in a default location.
+    See the [Phoebus Preference Settings] documentation for more information.
+
+- Phoebus save-and-restore now requires authentication
+  for all non read-only operations.
+  This means that the new option {nix:option}`services.phoebus-save-and-restore.settings."auth.impl"`
+  is now required.
+  Examine the updated guide {doc}`../nixos-services/user-guides/phoebus-save-and-restore`
+  for how to use it.
+
+## Highlights
+
+- Archiver Appliance was upgrade from 1.1.0 -> 2.0.5,
+  see the [Archiver Appliance 2.0.5 release notes].
+  None of the breaking change should affect users of the
+  {option}`services.archiver-appliance` NixOS options.
+
+[archiver appliance 2.0.5 release notes]: https://github.com/archiver-appliance/epicsarchiverap/releases/tag/2.0.5
+[Phoebus Preference Settings]: https://control-system-studio.readthedocs.io/en/latest/preferences.html

--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -56,18 +56,16 @@ in {
             apply = lib.concatStringsSep ",";
           };
 
-          es_host = lib.mkOption {
-            description = "Elasticsearch server host";
-            type = lib.types.str;
-            default = "localhost";
-          };
+          es_urls = lib.mkOption {
+            description = ''
+              List of Elasticsearch node URLs.
 
-          es_port = lib.mkOption {
-            description = "Elasticsearch server port";
-            type = lib.types.port;
-            default = config.services.elasticsearch.port;
-            defaultText = lib.literalExpression "config.services.elasticsearch.port";
-            apply = toString;
+              All nodes must belong to the same cluster.
+            '';
+            type = with lib.types; listOf str;
+            default = ["http://localhost:${toString config.services.elasticsearch.port}"];
+            defaultText = lib.literalExpression ''[ "http://localhost:''${toString config.services.elasticsearch.port}" ]'';
+            apply = lib.concatStringsSep ",";
           };
 
           es_sniff = lib.mkOption {

--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -36,7 +36,7 @@ in {
         Note that options containing a "." must be quoted.
 
         Available options can be seen here:
-        https://github.com/ControlSystemStudio/phoebus/blob/master/services/alarm-logger/src/main/resources/application.properties
+        <https://github.com/ControlSystemStudio/phoebus/blob/v${pkgs.epnix.phoebus-alarm-logger.version}/services/alarm-logger/src/main/resources/application.properties>
       '';
       default = {};
       type = lib.types.submodule {

--- a/nixos/modules/phoebus/save-and-restore.nix
+++ b/nixos/modules/phoebus/save-and-restore.nix
@@ -38,7 +38,7 @@ in {
         Note that options containing a "." must be quoted.
 
         Available options can be seen here:
-        https://github.com/ControlSystemStudio/phoebus/blob/master/services/save-and-restore/src/main/resources/application.properties
+        <https://github.com/ControlSystemStudio/phoebus/blob/v${pkgs.epnix.phoebus-save-and-restore.version}/services/save-and-restore/src/main/resources/application.properties>
       '';
       default = {};
       type = lib.types.submodule {
@@ -49,6 +49,114 @@ in {
             type = lib.types.port;
             default = 8080;
             apply = toString;
+          };
+
+          "auth.impl" = lib.mkOption {
+            description = ''
+              Authentication implementation.
+
+              Supported options:
+
+              `"ad"`
+              :   Microsoft Active Directory
+
+              `"ldap"`
+              :   LDAP
+
+              `"ldap_embedded"`
+              :   Embedded LDAP. Config in sar.ldif
+
+              `"demo"`
+              :   Hard coded users and passwords.
+                  Provides 3 users:
+
+                  -   an admin
+                  -   a read-only user
+                  -   a normal user
+
+                  See the following options:
+
+                  -   {nix:option}`"demo.admin"`
+                  -   {nix:option}`"demo.admin.password"`
+                  -   {nix:option}`"demo.readOnly"`
+                  -   {nix:option}`"demo.readOnly.password"`
+                  -   {nix:option}`"demo.user"`
+                  -   {nix:option}`"demo.user.password"`
+            '';
+            type = lib.types.enum ["ad" "ldap" "ldap_embedded" "demo"];
+          };
+
+          "demo.user" = lib.mkOption {
+            description = ''
+              Username for the normal demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "user";
+          };
+
+          "demo.user.password" = lib.mkOption {
+            description = ''
+              Password for the normal demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "userPass";
+          };
+
+          "demo.admin" = lib.mkOption {
+            description = ''
+              Username for the admin demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "admin";
+          };
+
+          "demo.admin.password" = lib.mkOption {
+            description = ''
+              Password for the admin demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "adminPass";
+          };
+
+          "demo.readOnly" = lib.mkOption {
+            description = ''
+              Username for the normal demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "johndoe";
+          };
+
+          "demo.readOnly.password" = lib.mkOption {
+            description = ''
+              Password for the read-only demo user.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"demo"`.
+            '';
+            type = lib.types.str;
+            default = "1234";
+          };
+
+          "spring.ldap.embedded.ldif" = lib.mkOption {
+            description = ''
+              Path to [LDIF] file describing the content of the embedded LDAP server.
+
+              Only valid for if {nix:option}`"auth.impl"` is `"embedded_ldap"`.
+
+                [LDIF]: https://en.wikipedia.org/wiki/LDAP_Data_Interchange_Format
+            '';
+            type = lib.types.str;
+            default = "classpath:sar.ldif";
+            example = lib.literalExpression ''"file://''${./sar.ldif}"'';
           };
 
           "elasticsearch.network.host" = lib.mkOption {

--- a/nixos/tests/phoebus/alarm.py
+++ b/nixos/tests/phoebus/alarm.py
@@ -180,8 +180,8 @@ with subtest("The data is still here after a server reboot"):
     wait_for_boot()
 
     alarm = get_alarm()
-    assert alarm["current_severity"] == "OK"
-    assert alarm["severity"] == "OK"
+    assert alarm["current_severity"] == "OK", "wrong current severity"
+    assert alarm["severity"] == "OK", "wrong severity"
 
     logger_alarms = get_logger("/search/alarm/pv/ALARM_TEST")
     logger_alarms.sort(key=lambda event: event.get("time", ""), reverse=True)
@@ -189,9 +189,9 @@ with subtest("The data is still here after a server reboot"):
         alarm for alarm in logger_alarms if alarm["config"].startswith("state:")
     ]
 
-    assert alarm_states[2]["current_severity"] == "MAJOR"
-    assert alarm_states[2]["severity"] == "MAJOR"
-    assert alarm_states[2]["value"] == "4.0"
+    assert alarm_states[2]["current_severity"] == "MAJOR", "wrong current severity"
+    assert alarm_states[2]["severity"] == "MAJOR", "wrong severity"
+    assert alarm_states[2]["value"] == "4.0", "wrong value"
 
 with subtest("Can export alarm configuration"):
     server.succeed(

--- a/nixos/tests/phoebus/save-and-restore.ldif
+++ b/nixos/tests/phoebus/save-and-restore.ldif
@@ -1,0 +1,77 @@
+dn: dc=sar,dc=local
+objectClass: dcObject
+objectClass: organization
+dc: sar
+o: sar
+
+dn: cn=sar,dc=sar,dc=local
+objectClass: simpleSecurityObject
+objectClass: organizationalRole
+userPassword:: e1NIQX1jUkR0cE5DZUJpcWw1S09Rc0tWeXJBMHNBaUE9
+cn: sar
+
+dn: ou=Group,dc=sar,dc=local
+objectClass: organizationalunit
+ou: Group
+description: groups branch
+
+dn: cn=sar-user,ou=Group,dc=sar,dc=local
+cn: sar-user
+objectClass: posixGroup
+description: save-n-restore user
+gidNumber: 27001
+uidNumber: 27001
+memberUid: user
+
+dn: cn=sar-admin,ou=Group,dc=sar,dc=local
+cn: sar-admin
+objectClass: posixGroup
+description: save-n-restore admin
+gidNumber: 27003
+uidNumber: 27003
+memberUid: admin
+memberUid: customAdmin
+
+dn: uid=user,ou=Group,dc=sar,dc=local
+uid: user
+objectClass: account
+objectClass: posixAccount
+description: User with sar-user role
+cn: user
+userPassword: userPass
+uidNumber: 23004
+gidNumber: 23004
+homeDirectory: /dev/null
+
+dn: uid=johndoe,ou=Group,dc=sar,dc=local
+uid: johndoe
+objectClass: account
+objectClass: posixAccount
+description: User without sar roles
+cn: johndoe
+userPassword: 1234
+uidNumber: 23007
+gidNumber: 23007
+homeDirectory: /dev/null
+
+dn: uid=admin,ou=Group,dc=sar,dc=local
+uid: admin
+objectClass: account
+objectClass: posixAccount
+description: User with admin role
+cn: admin
+userPassword: adminPass
+uidNumber: 23005
+gidNumber: 23005
+homeDirectory: /dev/null
+
+dn: uid=customAdmin,ou=Group,dc=sar,dc=local
+uid: customAdmin
+objectClass: account
+objectClass: posixAccount
+description: Custom user with admin role
+cn: customAdmin
+userPassword: customAdminPass
+uidNumber: 23006
+gidNumber: 23006
+homeDirectory: /dev/null

--- a/nixos/tests/phoebus/save-and-restore.nix
+++ b/nixos/tests/phoebus/save-and-restore.nix
@@ -11,6 +11,11 @@
       services.phoebus-save-and-restore = {
         enable = true;
         openFirewall = true;
+
+        settings = {
+          "auth.impl" = "ldap_embedded";
+          "spring.ldap.embedded.ldif" = "file://${./save-and-restore.ldif}";
+        };
       };
 
       services.elasticsearch = {

--- a/nixos/tests/phoebus/save-and-restore.py
+++ b/nixos/tests/phoebus/save-and-restore.py
@@ -25,6 +25,7 @@ def put(uri: str, data: JSON):
         client.succeed(
             "curl -sSf "
             "-X PUT "
+            "-u customAdmin:customAdminPass "
             "-H 'Content-Type: application/json' "
             "-H 'Accept: application/json' "
             f"'{base_url}{uri}' "
@@ -37,6 +38,7 @@ def delete(uri: str):
     client.succeed(
         "curl -sSf "
         "-X DELETE "
+        "-u customAdmin:customAdminPass "
         "-H 'Content-Type: application/json' "
         "-H 'Accept: application/json' "
         f"'{base_url}{uri}'"
@@ -60,6 +62,7 @@ with subtest("We can create a subnode"):
     result = put(
         f"/node?parentNodeId={root_node_id}",
         {
+            "nodeType": "FOLDER",
             "name": "subnode",
             "description": "A test subnode",
             "userName": user,
@@ -79,6 +82,7 @@ with subtest("We can create a config"):
         {
             "configurationNode": {
                 "name": "test configuration",
+                "nodeType": "CONFIGURATION",
                 "userName": user,
             },
             "configurationData": {
@@ -145,6 +149,7 @@ with subtest("We can create a snapshot"):
         {
             "snapshotNode": {
                 "name": "test snapshot",
+                "nodeType": "SNAPSHOT",
                 "userName": user,
             },
             "snapshotData": {

--- a/pkgs/epnix/tools/phoebus/deps/default.nix
+++ b/pkgs/epnix/tools/phoebus/deps/default.nix
@@ -8,13 +8,13 @@
 }:
 stdenv.mkDerivation {
   pname = "phoebus-deps";
-  version = "4.7.3";
+  version = "4.7.4";
 
   src = fetchFromGitHub {
     owner = "ControlSystemStudio";
     repo = "phoebus";
-    rev = "v4.7.3";
-    hash = "sha256-1Q66iZ+mTXzQ9pjW5wypG7q7rPy9K+PUcQXsKKk2sNo=";
+    rev = "v4.7.4";
+    hash = "sha256-/jyEafX1G/WasIRqyrn1DaNgoQ6osueTmviGaObuhAg=";
   };
 
   nativeBuildInputs = [jdk maven];
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "sha256-WPTw40NQQclYE3z283yVmd5epP01R0oMsI+1UuADGB4=";
+  outputHash = "sha256-YQsL1EbqyDHtlqXm4C3NmMpqq6LDZzhhjtQfwcB6yfs=";
 
   doCheck = false;
 


### PR DESCRIPTION
Hi all,

Since a new version of phoebus is released, we wanted to update as well. It requires some updating of the phoebus deps, and we figured we would upstream this. Since there is already an update of phoebus in master, we just based it off of those commits, with a slight catch: we didn't want to upgrade to version 5.0.0 (even though it is practically the same). For one because it is a major release, but the main reason is that the git history seems a bit messed up for v5.0.0 (see [this thread](https://github.com/ControlSystemStudio/phoebus/issues/3382#issuecomment-2827694235), as the tagged commit is _not_ on the master branch, which we fear may cause some issues in fast forwarding in the future. The only real difference is the version number and the hashes corresponding to the phoebus-deps.