### PR TITLE
nixos/recceiver: fix addrlist option description

### DIFF
--- a/nixos/modules/channel-finder/recceiver.nix
+++ b/nixos/modules/channel-finder/recceiver.nix
@@ -83,11 +83,7 @@ in {
               default = ["255.255.255.255:5049"];
               apply = lib.concatStringsSep ",";
               description = ''
-                Listen for TCP connections on this interface and port.
-
-                Port also used as source for UDP broadcasts
-
-                Default uses wildcard address and a random port.
+                List of broadcast addresses.
               '';
             };
 


### PR DESCRIPTION
Previous description was a bad copy-paste.
New description is from the [RecCeiver demo.conf file].

  [RecCeiver demo.conf file]: https://github.com/ChannelFinder/recsync/blob/1.6/server/demo.conf