### PR TITLE
[nixos-23.11] pkgs/docs: create "alias" of the book package

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -94,6 +94,10 @@ in
 
       # EPNix specific packages
       book = callPackage ./book {};
+      docs = final.runCommand "docs-23.11" {meta.hidden = true;} ''
+        mkdir -p $out/share/doc/epnix
+        ln -sfn ${self.book} $out/share/doc/epnix/html
+      '';
       manpages = callPackage ./manpages {};
 
       # Documentation support packages


### PR DESCRIPTION
The `docs` package is basically the same as the `book` package, but it builds the doc in `share/doc/epnix/html`,
as expected by the `build-docs-multiversion` script on master.

This allows us to build this older version of the documentation, and make it show up on the EPNix website.