### PR TITLE
Factorize versions information

### DIFF
--- a/.github/workflows/book-gh-pages.yml
+++ b/.github/workflows/book-gh-pages.yml
@@ -32,22 +32,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
-      # Checkout all documentation versions
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: master
-          path: dev
-          persist-credentials: false
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: nixos-24.11
-          path: nixos-24.11
-          persist-credentials: false
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: nixos-24.05
-          path: nixos-24.05
           persist-credentials: false
 
       - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
@@ -61,14 +47,14 @@ jobs:
 
       - name: "Build documentation books"
         run: |
-          nix run --print-build-logs './dev#ci-scripts/build-docs-multiversion'
+          nix run --print-build-logs '.#ci-scripts/build-docs-multiversion'
 
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          path: './book'
+          path: './outputs/out/book'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
+      - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
       - id: set-matrix
         name: Generate Nix checks matrix
         run: |

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
-    - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
+    - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
     - name: "Check EditorConfig"
       run: nix run 'nixpkgs#eclint' --inputs-from .

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
-    - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
+    - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
     - name: "Check Formatting"
       run: nix fmt -- --check .

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
+      - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
       - id: set-matrix
         run: |
           set -Eeu
@@ -44,7 +44,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
           persist-credentials: false
-      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
+      - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
       - uses: DeterminateSystems/update-flake-lock@428c2b58a4b7414dabd372acb6a03dba1084d3ab # v25
         with:
           branch: "update-flake-lock/${{ matrix.branch }}"

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -13,14 +13,28 @@ permissions:
   contents: read
 
 jobs:
+  nix-matrix:
+    if: "github.repository_owner == 'epics-extensions'"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
+      - id: set-matrix
+        run: |
+          set -Eeu
+          matrix="$(nix eval --json '.#lib.ci.update-flake-lock-matrix')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   lockfile:
     if: "github.repository_owner == 'epics-extensions'"
+    name: update-flake-lock (${{ matrix.branch }})
+    needs: nix-matrix
     strategy:
-      matrix:
-        branch:
-          - master
-          - nixos-24.11
-          - nixos-24.05
+      matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
     permissions:
       contents: write # to create branch
       pull-requests: write # to create PR to backport

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9 # v27
+      - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
       - name: Run zizmor 🌈
         run: nix run 'nixpkgs#zizmor' -- --format sarif . > results.sarif
         env:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ sys.path.append(os.path.abspath("./_ext"))
 
 project = "EPNix"
 author = "The EPNix Contributors"
-release = "dev"
+release = os.environ.get("EPNIX_VERSION_CURRENT", "dev")
 
 source_repository = "https://github.com/epics-extensions/EPNix"
 branch = "master" if release == "dev" else release

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,15 @@ myst_enable_extensions = {
     "fieldlist",
     "replacements",
     "smartquotes",
+    "substitution",
+}
+
+myst_substitutions = {
+    "release": release,
+    "versions": {
+        "current": release,
+        "stable": os.environ.get("EPNIX_VERSION_STABLE", "dev"),
+    },
 }
 
 myst_heading_anchors = 2

--- a/docs/development/guides/release-process.md
+++ b/docs/development/guides/release-process.md
@@ -37,7 +37,6 @@ You should find at least:
 
 - the `nixpkgs` flake input in <source:flake.nix>
 - the `epnix` flake input in <source:templates/top/flake.nix>
-- workflows in <source:.github/workflows/>
 - documentation code examples
 
 Once done,

--- a/docs/development/guides/release-process.md
+++ b/docs/development/guides/release-process.md
@@ -29,7 +29,7 @@ running the tests will most likely show whether an incompatible change was intro
 ## Upgrade Nixpkgs
 
 Search for the old release version,
-for example `nixos-23.11`,
+for example *{{versions.stable}}*,
 and make sure to replace with the newer version,
 when appropriate.
 

--- a/docs/development/guides/release-process.md
+++ b/docs/development/guides/release-process.md
@@ -28,25 +28,16 @@ running the tests will most likely show whether an incompatible change was intro
 
 ## Upgrade Nixpkgs
 
-Search for the old release version,
-for example *{{versions.stable}}*,
-and make sure to replace with the newer version,
-when appropriate.
+### Update the flake input
 
-You should find at least:
+Replace the version of the `nixpkgs` input it <source:flake.nix>,
+and run `nix flake lock`.
 
-- the `nixpkgs` flake input in <source:flake.nix>
-- the `epnix` flake input in <source:templates/top/flake.nix>
-- documentation code examples
-
-Once done,
-run `nix flake lock`,
-and create a commit with these changes.
-
+Create a commit with these changes.
 The commit message should be:
 {samp}`flake: upgrade NixOS {old.version} -> {new.version}`.
 
-## Update Maven hashes
+### Update Maven hashes
 
 Maven hashes might depend on the Java or Maven version used,
 so a major Nixpkgs upgrade might cause those hashes to change.
@@ -74,7 +65,7 @@ if needed.
 
 Create a separate commit for each hash update.
 
-## Apply breaking changes
+### Apply breaking changes
 
 If there are breaking changes in the Nixpkgs release notes,
 apply them when appropriate,
@@ -94,7 +85,7 @@ in the Phoebus services guides.
 
 Create a commit for each breaking change.
 
-## Document breaking changes
+### Document breaking changes
 
 If some breaking changes in Nixpkgs or EPNix affect users,
 document them in the release notes,
@@ -106,7 +97,7 @@ add instructions on how to migrate to the new configuration format
 in the release notes.
 :::
 
-## Fix comments
+### Fix comments
 
 If there are "TODOs" in the code base that mention the new release,
 see if they can be solved.
@@ -118,7 +109,7 @@ and related code block.
 
 Create a commit for each resolved TODO.
 
-## Run the tests
+### Run the tests
 
 Run the EPNix checks.
 This can be done by pushing your branch to DRF's GitLab,
@@ -135,6 +126,82 @@ If there are issues with some tests,
 fix them,
 and add a commit for each fix.
 
+## Upgrade EPNix versions
+
+Search for the old EPNix release version,
+for example `nixos-24.05`,
+and make sure to replace with the newer version,
+when appropriate.
+
+You should find at least:
+
+- the `epnix` flake input in <source:templates/top/flake.nix>
+- the `stable` and `all` variables in <source:lib/versions.nix>
+- documentation code examples
+
+:::{admonition} Example
+```{code-block} nix
+:caption: Updating {file}`templates/top/flake.nix`
+:emphasize-lines: 3
+
+{
+  # ...
+  inputs.epnix.url = "github:epics-extensions/epnix/nixos-24.11";
+
+  # ...
+}
+```
+
+```{code-block} nix
+:caption: Updating {file}`lib/versions.nix`
+:emphasize-lines: 4,7
+
+let
+  self = {
+    current = "dev";
+    stable = "nixos-24.11";
+    all = [
+      "dev"
+      "nixos-24.11"
+      "nixos-24.05"
+      "nixos-23.11"
+      "nixos-23.05"
+    ];
+    # ...
+  };
+in
+  self
+```
+
+``````{code-block} markdown
+:caption: Updating the Archiver Appliance tutorial
+:emphasize-lines: 8,9
+
+```{code-block} nix
+:caption: {file}`flake.nix`
+:linenos:
+
+{
+  description = "Configuration for running Archiver Appliance in a VM";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  inputs.epnix.url = "github:epics-extensions/EPNix/nixos-24.11";
+
+  outputs = { self, nixpkgs, epnix }: {
+    nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
+      modules = [
+        epnix.nixosModules.nixos
+
+        ./configuration.nix
+      ];
+    };
+  };
+}
+```
+``````
+
+:::
+
 ## Open a pull request
 
 Once you've verified that the new version is working,
@@ -145,25 +212,34 @@ open one or more Pull Requests with your changes on GitHub.
 Once your Pull Request is merged,
 and you've integrated all changes you want for the new release,
 go into GitHub's [branches view],
-and create a new {samp}`nixos-{new.version}` branch on master.
+and create a new {samp}`nixos-{new.version}` branch on `master`.
 
-## Update the documentation release name
+## Update EPNix versions for that release
 
 Create a new commit
 on the new {samp}`nixos-{new.version}` branch,
-and update the `release` variable in <source:docs/conf.py>,
-so that it is {samp}`nixos-{new.version}`.
+and update the `current` variable in <source:lib/versions.nix>:
 
 :::{admonition} Example
-```{code-block} python
-:caption: {file}`docs/conf.py`
-:emphasize-lines: 5
+```{code-block} nix
+:caption: Updating {file}`lib/versions.nix` on the new release branch
+:emphasize-lines: 3
 
-project = "EPNix"
-copyright = "The EPNix Contributors"
-author = "The EPNix Contributors"
-release = "dev"
-release = "nixos-24.05"
+let
+  self = {
+    current = "nixos-24.11";
+    stable = "nixos-24.11";
+    all = [
+      "dev"
+      "nixos-24.11"
+      "nixos-24.05"
+      "nixos-23.11"
+      "nixos-23.05"
+    ];
+    # ...
+  };
+in
+  self
 ```
 :::
 
@@ -173,55 +249,15 @@ since the book must be built from the default branch.
 Open a Pull Request with that commit,
 targeting the {samp}`nixos-{new.version}` branch.
 
-## Build the new version of the manual
+## Build the new version of the documentation
 
-Create a new commit
-on the `master` branch,
-and update the <source:.github/workflows/book-gh-pages.yml> workflow to clone the newest release:
+The documentation job might have failed,
+since we added {sap}`nixos-{new.version}` in <source:lib/versions.nix>
+before creating the branch.
 
-:::{admonition} Example
-```{code-block} yaml
-:caption: {file}`.github/workflows/book-gh-pages.yml`
-:emphasize-lines: 6-10
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: master
-          path: dev
-          persist-credentials: false
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: nixos-24.05
-          path: nixos-24.05
-          persist-credentials: false
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: nixos-23.11
-          path: nixos-23.11
-          persist-credentials: false
-```
-:::
-
-Then add this the version to the build
-by changing {file}`pkgs/ci-scripts/build-docs-multiversion.nix`:
-
-:::{admonition} Example
-```{code-block} nix
-:caption: {file}`pkgs/ci-scripts/build-docs-multiversion.nix`:
-:emphasize-lines: 1,4
-
-  stable = "nixos-24.05";
-  versions = [
-    "dev"
-    "nixos-24.05"
-    "nixos-23.11"
-    # ...
-  ];
-```
-:::
-
-Open a Pull Request with that commit,
-targeting the {samp}`master` branch.
+To build the manual,
+on GitHub,
+click the {menuselection}`Actions tab --> Book GitHub Pages --> Run workflow --> Run workflow`.
 
 [branches view]: https://github.com/epics-extensions/EPNix/branches
 [nixos release notes]: https://nixos.org/manual/nixos/stable/release-notes

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,12 +50,12 @@ read the {doc}`NixOS services tutorials <nixos-services/tutorials/index>`
 
 ## Release branches
 
-EPNix has a `master` branch,
+EPNix has a *master* branch,
 which is considered unstable,
 meaning breaking changes might happen without notice.
 
 EPNix also has release branches,
-such as `nixos-24.11`,
+such as *{{versions.stable}}*,
 tied to the nixpkgs release branches,
 where breaking changes are forbidden.
 

--- a/flake.nix
+++ b/flake.nix
@@ -112,8 +112,8 @@
 
           Useful links:
 
-          - EPNix IOC documentation: <https://epics-extensions.github.io/EPNix/nixos-24.11/ioc/>
-          - EPNix IOC tutorials: <https://epics-extensions.github.io/EPNix/nixos-24.11/ioc/tutorials/>
+          - EPNix IOC documentation: <https://epics-extensions.github.io/EPNix/${self.lib.versions.stable}/ioc/>
+          - EPNix IOC tutorials: <https://epics-extensions.github.io/EPNix/${self.lib.versions.stable}/ioc/tutorials/>
         '';
       };
 
@@ -127,8 +127,8 @@
 
           Useful links:
 
-          - EPNix IOC documentation: <https://epics-extensions.github.io/EPNix/nixos-24.11/ioc/>
-          - EPNix IOC tutorials: <https://epics-extensions.github.io/EPNix/nixos-24.11/ioc/tutorials/>
+          - EPNix IOC documentation: <https://epics-extensions.github.io/EPNix/${self.lib.versions.stable}/ioc/>
+          - EPNix IOC tutorials: <https://epics-extensions.github.io/EPNix/${self.lib.versions.stable}/ioc/tutorials/>
         '';
       };
 

--- a/lib/ci.nix
+++ b/lib/ci.nix
@@ -1,0 +1,5 @@
+{epnixLib, ...}: {
+  update-flake-lock-matrix = {
+    branch = epnixLib.versions.supported-branches;
+  };
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,6 +14,7 @@ with lib; let
     licenses = import ./licenses.nix args;
     maintainers = import ./maintainers/maintainer-list.nix;
     testing = import ./testing.nix;
+    versions = import ./versions.nix;
 
     inherit (self.evaluation) evalEpnixModules mkEpnixBuild mkEpnixDevShell;
 
@@ -60,7 +61,9 @@ with lib; let
             then "windows"
             else (throw "Unsupported architecture for windows: ${arch}");
         }
-        .${parsed.kernel.name}
+        .${
+          parsed.kernel.name
+        }
         or (throw "Unsupported kernel type: ${parsed.kernel.name}");
 
       arch =
@@ -85,7 +88,9 @@ with lib; let
 
           sparc = "sparc";
         }
-        .${parsed.cpu.family}
+        .${
+          parsed.cpu.family
+        }
         or (throw "Unsupported architecture: ${parsed.cpu.name}");
     in "${kernel}-${arch}";
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -8,6 +8,7 @@ with lib; let
   self = {
     inherit inputs;
 
+    ci = import ./ci.nix args;
     documentation = import ./documentation.nix args;
     evaluation = import ./evaluation.nix args;
     formats = import ./formats.nix args;

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -14,6 +14,10 @@ let
       then "master"
       else version)
     self.all;
+    supported-branches = [
+      "master"
+      self.stable
+    ];
   };
 in
   self

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -1,0 +1,19 @@
+let
+  self = {
+    current = "dev";
+    stable = "nixos-24.11";
+    all = [
+      "dev"
+      "nixos-24.11"
+      "nixos-24.05"
+      "nixos-23.11"
+      "nixos-23.05"
+    ];
+    all-branches = map (version:
+      if version == "dev"
+      then "master"
+      else version)
+    self.all;
+  };
+in
+  self

--- a/pkgs/by-name/docs/package.nix
+++ b/pkgs/by-name/docs/package.nix
@@ -185,6 +185,7 @@ in
       TYPST_PACKAGE_CACHE_PATH = "${typst-packages-vendor}";
       SOURCE_DATE_EPOCH = epnixLib.inputs.self.sourceInfo.lastModified;
       EPNIX_VERSION_CURRENT = epnixLib.versions.current;
+      EPNIX_VERSION_STABLE = epnixLib.versions.stable;
     };
 
     meta = {

--- a/pkgs/by-name/docs/package.nix
+++ b/pkgs/by-name/docs/package.nix
@@ -184,6 +184,7 @@ in
       TYPST_PACKAGE_PATH = "${typst-packages-vendor}";
       TYPST_PACKAGE_CACHE_PATH = "${typst-packages-vendor}";
       SOURCE_DATE_EPOCH = epnixLib.inputs.self.sourceInfo.lastModified;
+      EPNIX_VERSION_CURRENT = epnixLib.versions.current;
     };
 
     meta = {

--- a/pkgs/ci-scripts/by-name/build-docs-multiversion/package.nix
+++ b/pkgs/ci-scripts/by-name/build-docs-multiversion/package.nix
@@ -4,9 +4,13 @@
   writeText,
   writers,
   epnixLib,
+  curl,
+  gnutar,
+  gzip,
 }: let
   inherit (epnixLib.versions) stable;
   versions = epnixLib.versions.all;
+  version-branches = epnixLib.versions.all-branches;
   baseurl = "https://epics-extensions.github.io/EPNix";
   # Make a redirection using the <meta> tag,
   # with a delay of 1 second, because Google considers them not permanent
@@ -16,6 +20,8 @@
   redirect = writeText "stable-redirect.html" ''
     <meta http-equiv=refresh content="1;url=${stable}/">
   '';
+
+  source-repository = "https://github.com/epics-extensions/EPNix";
 
   # Put the stable version first
   versionsbyPriority = [stable] ++ (lib.remove stable versions);
@@ -56,18 +62,36 @@ in
   writeShellApplication {
     name = "build-docs-multiversion";
 
+    runtimeInputs = [curl gnutar gzip];
+
     text = ''
+      mkdir -p outputs/out
+      out="$(pwd)/outputs/out"
+      cd "$(mktemp -d)"
+
+      # Download every specified branch of EPNix
+      for version in ${toString version-branches}; do
+        curl -LSf "${source-repository}/archive/refs/heads/$version.tar.gz" | tar xz
+        mv "EPNix-$version" "$version"
+      done
+
+      # The "master" branch is called "dev"
+      mv master dev
+
+      # Build the documentation
       for version in ${toString versions}; do
         mkdir -p "./book/$version"
-        cp ${versions_json} "./$version/docs/versions.json"
-        git -C "$version" add docs/versions.json
+        [[ -d "$version/docs" ]] && cp ${versions_json} "./$version/docs/versions.json"
         nix build "./$version#docs" --print-build-logs
         cp -LrT --no-preserve=mode,ownership ./result/share/doc/epnix/html "./book/$version"
       done
+
       cp ${redirect} ./book/index.html
       cp ${sitemap} ./book/sitemap.xml
       cp ${robots} ./book/robots.txt
       echo "google-site-verification: googlec2385d4b797d68b3.html" > ./book/googlec2385d4b797d68b3.html
+
+      cp -avfT book "$out/book"
     '';
 
     meta = {

--- a/pkgs/ci-scripts/by-name/build-docs-multiversion/package.nix
+++ b/pkgs/ci-scripts/by-name/build-docs-multiversion/package.nix
@@ -5,12 +5,8 @@
   writers,
   epnixLib,
 }: let
-  stable = "nixos-24.11";
-  versions = [
-    "dev"
-    "nixos-24.11"
-    "nixos-24.05"
-  ];
+  inherit (epnixLib.versions) stable;
+  versions = epnixLib.versions.all;
   baseurl = "https://epics-extensions.github.io/EPNix";
   # Make a redirection using the <meta> tag,
   # with a delay of 1 second, because Google considers them not permanent


### PR DESCRIPTION
Try to define EPNix version information in a single place, as much as possible.

This means less work to do for EPNix releases, because less places to update.

- For GitHub actions, we dynamically generate a matrix job, instead of hardcoding
- For building the documentation website, the bash script now fetches the various EPNix versions by itself, instead of using the `actions/checkout` action
  - Depends on #336 and its backport
- For documentation, we use [MyST's substitutions](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#substitutions-with-jinja2)

Things that I couldn't update:

- Code blocks in documentation (MyST substitutions doesn't work in code blocks)
- The `flake.nix` in Nix templates (from what I remember, it can't be generated)

I also changed the install nix action to use the one from nixbuild, which should be faster.