### PR TITLE
flake: upgrade NixOS 24.11 -> 25.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,16 +125,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749173751,
-        "narHash": "sha256-ENY3y3v6S9ZmLDDLI3LUT8MXmfXg/fSt2eA4GCnMVCE=",
+        "lastModified": 1749857119,
+        "narHash": "sha256-tG5xUn3hFaPpAHYIvr2F88b+ovcIO5k1HqajFy7ZFPM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed29f002b6d6e5e7e32590deb065c34a31dc3e91",
+        "rev": "5f4f306bea96741f1588ea4f450b2a2e29f42b98",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A Nix flake containing EPICS-related modules and packages";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     bash-lib = {
       url = "github:minijackson/bash-lib";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
As specified by the [Release process guide](https://epics-extensions.github.io/EPNix/dev/development/guides/release-process.html), but just the nixpkgs upgrade part, because I need `treefmt.withConfig` for fixing #279, that I want to do before the real release.