### PR TITLE
pyepics: 3.5.7 -> 3.5.8

### DIFF
--- a/pkgs/python-modules/by-name/pyepics/package.nix
+++ b/pkgs/python-modules/by-name/pyepics/package.nix
@@ -12,12 +12,12 @@
 }:
 buildPythonPackage rec {
   pname = "pyepics";
-  version = "3.5.7";
+  version = "3.5.8";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-vj/YeBcaZvukK/QFFASxKzbe2KRIrBiU8PgcnyszDX8=";
+    hash = "sha256-1E5qyUBLWoJ6UiTN43Q4e0f28/iRyEN929L5+5E7ulE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Release notes: https://github.com/pyepics/pyepics/releases/tag/3.5.8