### PR TITLE
ioc/modules/common: make unconditional warning nicer

### DIFF
--- a/ioc/modules/common.nix
+++ b/ioc/modules/common.nix
@@ -55,14 +55,16 @@ with lib;
     warnings = [
       # Unconditional warning
       ''
-        For IOC ${config.epnix.meta.name}:
-
         Developing IOCs using modules is deprecated,
         and will be removed in version `nixos-26.05`.
 
         See the User Guide "Migrating from modules development"
         in the IOC documentation
         to see how to migrate your IOC.
+
+        If you're not packaging any IOC using modules in this configuration,
+        make sure you're importing `epnix.nixosModules.nixos`,
+        and *not* `epnix.nixosModules.default` or `epnix.nixosModules.ioc`.
       ''
     ];
 


### PR DESCRIPTION
Now if the user imports the IOC modules facility by mistake, the configuration still evaluates, and the warnings indicates what the user needs to do.

Before, the warning was using `config.epnix.meta.name`, which wouldn't be defined, if the user didn't have any IOC.