### PR TITLE
github/build-checks: don't run on push

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -3,6 +3,9 @@ name: "Nix flake checks"
 on:
   pull_request:
   push:
+    branches:
+      - "master"
+      - "nixos-*"
 
 permissions:
   contents: read


### PR DESCRIPTION
Only run in the main branches, else in PRs, the jobs has double the work to do