### PR TITLE
github/docs-linkcheck: fix workflow

### DIFF
--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -16,6 +16,7 @@ jobs:
   linkcheck:
     if: "github.repository_owner == 'epics-extensions'"
 
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Missing "runs-on" attribute