### PR TITLE
github/build-checks: only one workflow per PR

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -10,6 +10,13 @@ on:
 permissions:
   contents: read
 
+# One workflow per PR,
+# and cancel in-progress workflows for PRs,
+# but not for other jobs
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   nix-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This limits the number of jobs in total, which should leads to faster job pick-ups for PRs.