### PR TITLE
docs: configure Intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ nitpicky = True
 
 extensions = [
     "myst_parser",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.githubpages",
     "sphinx_copybutton",
     "sphinxcontrib_nixdomain",
@@ -97,6 +98,18 @@ myst_url_schemes = {
         "title": "Issue #{{path}}",
         "classes": ["github"],
     },
+}
+
+# -- Options for intersphinx -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+
+intersphinx_mapping = {
+    "epics": ("https://docs.epics-controls.org/en/latest/", None),
+    "epics-base": ("https://docs.epics-controls.org/projects/base/en/latest/", None),
+    "myst": ("https://myst-parser.readthedocs.io/en/latest", None),
+    "python": ("https://docs.python.org/3", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
+    "nixdomain": ("https://minijackson.github.io/sphinxcontrib-nixdomain/", None),
 }
 
 # -- Options for Sphinx Copybutton -------------------------------------------

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -7,8 +7,6 @@ let
       "nixos-25.05"
       "nixos-24.11"
       "nixos-24.05"
-      "nixos-23.11"
-      "nixos-23.05"
     ];
     all-branches = map (version: if version == "dev" then "master" else version) self.all;
     supported-branches = [


### PR DESCRIPTION
This needed building the documentation outside of the Nix sandbox, due to the internet connection requirement.

Also disables the build of the 23.11 and 23.05 EPNix version, because it caused issues with the "outside of the sandbox" thing. I don't think they have many users, in any case.