### PR TITLE
phoebus-olog: 4.7.7 -> 5.0.4

### DIFF
--- a/nixos/tests/phoebus/olog.nix
+++ b/nixos/tests/phoebus/olog.nix
@@ -66,12 +66,10 @@
 
     def put(uri: str, data: Any) -> Any:
         result = client.succeed(
-            f"""
-                curl -sSfL -k -X PUT -u admin:adminPass \
-                  'https://server:8181/Olog{uri}' \
-                  -H 'Content-Type: application/json' \
-                  -d {repr(json.dumps(data))}
-        """
+            "curl -sSfL -k -X PUT -u admin:adminPass "
+            f"'https://server:8181/Olog{uri}' "
+            "-H 'Content-Type: application/json' "
+            f"-d {repr(json.dumps(data))}"
         )
         return json.loads(result)
 
@@ -80,7 +78,12 @@
         assert len(logbooks) > 0, "No default logbook found"
 
     with subtest("can login"):
-        client.succeed("curl -sSfL -k -X POST 'https://server:8181/Olog/login?username=admin&password=adminPass' --cookie-jar cjar")
+        credentials = {"username": "admin", "password": "adminPass"}
+        client.succeed(
+            "curl -sSfL -k -X POST 'https://server:8181/Olog/login' "
+            f"-H 'Content-Type: application/json' -d {repr(json.dumps(credentials))} "
+            "--cookie-jar cjar"
+        )
         user_str = client.succeed("curl -sSfL -k 'https://server:8181/Olog/user' --cookie cjar")
         user = json.loads(user_str)
         assert user["userName"] == "admin"

--- a/pkgs/by-name/phoebus-olog/package.nix
+++ b/pkgs/by-name/phoebus-olog/package.nix
@@ -8,17 +8,17 @@
 }:
 maven.buildMavenPackage rec {
   pname = "phoebus-olog";
-  version = "4.7.7";
+  version = "5.0.4";
 
   src = fetchFromGitHub {
     owner = "Olog";
     repo = "phoebus-olog";
     rev = "v${version}";
-    hash = "sha256-AHZowe4mmBpiFd5MMVRrnUHeTOJDwE6f0sZFUF+07lo=";
+    hash = "sha256-UudG3ltEZMOcMgwVNZJKdlaJZ9XsRaEsyKwqzcJ0yDs=";
   };
 
-  mvnHash = "sha256-puUnYIbBVVXfoIcK9lkmBOH3TBfFAK+MeN8vsoxB8w0=";
-  mvnParameters = "-Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Pdeployable-jar -Dproject.build.outputTimestamp=1980-01-01T00:00:02Z";
+  mvnHash = "sha256-PQ1TN63Eq1hzdijamPTUMDV/6pV4+DyycQZJWLDypmw=";
+  mvnParameters = "-Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Pdeployable-jar";
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
Currently as draft, while we figure out the breaking changes.

The only one I know currently is the `/login` endpoint, which doesn't accept passing credentials through GET parameters anymore. You have to pass it as JSON in the request body.

@lcaouen do you know of any breaking change? 