### PR TITLE
phoebus-olog: fix deps reproducibility

### DIFF
--- a/pkgs/by-name/phoebus-olog/fix-deps-reproducibility.patch
+++ b/pkgs/by-name/phoebus-olog/fix-deps-reproducibility.patch
@@ -1,0 +1,12 @@
+diff --git i/pom.xml w/pom.xml
+index 59a6ed9..7cd978d 100644
+--- i/pom.xml
++++ w/pom.xml
+@@ -541,6 +541,7 @@
+                     <plugin>
+                         <groupId>org.springframework.boot</groupId>
+                         <artifactId>spring-boot-maven-plugin</artifactId>
++                        <version>${spring.boot-version}</version>
+                         <configuration>
+                             <executable>true</executable>
+                         </configuration>

--- a/pkgs/by-name/phoebus-olog/package.nix
+++ b/pkgs/by-name/phoebus-olog/package.nix
@@ -17,7 +17,9 @@ maven.buildMavenPackage rec {
     hash = "sha256-UudG3ltEZMOcMgwVNZJKdlaJZ9XsRaEsyKwqzcJ0yDs=";
   };
 
-  mvnHash = "sha256-PQ1TN63Eq1hzdijamPTUMDV/6pV4+DyycQZJWLDypmw=";
+  patches = [ ./fix-deps-reproducibility.patch ];
+
+  mvnHash = "sha256-xMiCU6k1cnlGUxqV35Qs20XOx9BMg7d5wPdNo6wTdHU=";
   mvnParameters = "-Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Pdeployable-jar";
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
The spring-boot-maven-plugin's version wasn't fixed, so Maven downloaded the version list from maven central and picked always the latest version,
which isn't reproducible since new versions are added over time.