### PR TITLE
docs: better prerequisites

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -5,7 +5,7 @@ You can download the cheatsheet in PDF format here:
 {download}`cheatsheet.pdf`
 :::
 
-See the {doc}`../pre-requisites`
+See the {doc}`../prerequisites`
 and the {doc}`../ioc/user-guides/flake-registry` guide
 before getting started.
 

--- a/docs/contributing/guides/release-process.md
+++ b/docs/contributing/guides/release-process.md
@@ -195,7 +195,7 @@ where breaking changes are forbidden.
 [NixOS services tutorials]: https://epics-extensions.github.io/EPNix/nixos-24.11/nixos-services/tutorials/index.html
 [Nix]: https://nixos.org/guides/how-nix-works/
 [Packages list]: https://epics-extensions.github.io/EPNix/nixos-24.11/pkgs/packages.html
-[Pre-requisites]: https://epics-extensions.github.io/EPNix/nixos-24.11/pre-requisites.html
+[Prerequisites]: https://epics-extensions.github.io/EPNix/nixos-24.11/prerequisites.html
 ```
 
 ``````{code-block} markdown

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ For more information about this approach,
 examine {doc}`advantages-disadvantages`.
 
 Before getting started,
-make sure to follow the {doc}`pre-requisites`.
+make sure to follow the {doc}`prerequisites`.
 
 ## Features
 
@@ -85,7 +85,7 @@ EPNix is under the MIT license.
 :titlesonly:
 
 advantages-disadvantages
-pre-requisites
+prerequisites
 cheatsheet
 release-notes/index
 ```

--- a/docs/ioc/tutorials/integration-tests.md
+++ b/docs/ioc/tutorials/integration-tests.md
@@ -15,7 +15,7 @@ and checking that it behaves as expected.
 This method of testing can then be automated
 by running it inside a Continuous Integration (CI) system.
 
-## Pre-requisites
+## Prerequisites
 
 :::{warning}
 Nix assumes you can run hardware-accelerated VMs,

--- a/docs/ioc/tutorials/streamdevice.md
+++ b/docs/ioc/tutorials/streamdevice.md
@@ -5,10 +5,10 @@ we're going to create an EPICS IOC with EPNix
 that communicates with a power supply,
 using the [StreamDevice] support module.
 
-## Pre-requisites
+## Prerequisites
 
-Verify that you have all pre-requisites installed,
-by following the {doc}`../../pre-requisites` section.
+Verify that you have all prerequisites installed,
+by following the {doc}`../../prerequisites` section.
 
 ## Running the power supply simulator
 

--- a/docs/ioc/user-guides/testing/unit-testing.md
+++ b/docs/ioc/user-guides/testing/unit-testing.md
@@ -166,7 +166,7 @@ which can be useful if you don't want to import an external EPICS module.
 [epicsUnitTest.h] is made in C,
 but tests can be written in either C or C++.
 
-### Pre-requisites
+### Prerequisites
 
 Examine gtest's {ref}`is-library`.
 

--- a/docs/nixos-services/user-guides/ca-gateway.md
+++ b/docs/nixos-services/user-guides/ca-gateway.md
@@ -11,7 +11,7 @@ For more details and documentation about the CA PV gateway,
 you can examine the [gateway main page].
 
 :::{important}
-Make sure to follow the NixOS {doc}`pre-requisites`.
+Make sure to follow the NixOS {doc}`prerequisites`.
 :::
 
 ## Enabling the gateway

--- a/docs/nixos-services/user-guides/ca-gateway.md
+++ b/docs/nixos-services/user-guides/ca-gateway.md
@@ -10,8 +10,9 @@ to add extra access security rules on top of IOCs.
 For more details and documentation about the CA PV gateway,
 you can examine the [gateway main page].
 
-```{include} ./pre-requisites.md
-```
+:::{important}
+Make sure to follow the NixOS {doc}`pre-requisites`.
+:::
 
 ## Enabling the gateway
 

--- a/docs/nixos-services/user-guides/channel-finder.md
+++ b/docs/nixos-services/user-guides/channel-finder.md
@@ -13,7 +13,7 @@ For more information on the ChannelFinder architecture,
 see the official [ChannelFinder introduction].
 
 :::{important}
-Make sure to follow the NixOS {doc}`pre-requisites`.
+Make sure to follow the NixOS {doc}`prerequisites`.
 :::
 
 ## ChannelFinder service

--- a/docs/nixos-services/user-guides/channel-finder.md
+++ b/docs/nixos-services/user-guides/channel-finder.md
@@ -12,8 +12,9 @@ that scans and retrieves the metadata from "RecCaster."
 For more information on the ChannelFinder architecture,
 see the official [ChannelFinder introduction].
 
-```{include} ./pre-requisites.md
-```
+:::{important}
+Make sure to follow the NixOS {doc}`pre-requisites`.
+:::
 
 ## ChannelFinder service
 

--- a/docs/nixos-services/user-guides/epics-environment.md
+++ b/docs/nixos-services/user-guides/epics-environment.md
@@ -17,7 +17,7 @@ such as ChannelFinder, and Phoebus services.
 :::
 
 :::{important}
-Make sure to follow the NixOS {doc}`pre-requisites`.
+Make sure to follow the NixOS {doc}`prerequisites`.
 :::
 
 ## Default behavior

--- a/docs/nixos-services/user-guides/epics-environment.md
+++ b/docs/nixos-services/user-guides/epics-environment.md
@@ -16,6 +16,10 @@ such as ChannelFinder, and Phoebus services.
 [EPICS environment variables] in the Channel Access Reference Manual.
 :::
 
+:::{important}
+Make sure to follow the NixOS {doc}`pre-requisites`.
+:::
+
 ## Default behavior
 
 By default,

--- a/docs/nixos-services/user-guides/index.md
+++ b/docs/nixos-services/user-guides/index.md
@@ -8,6 +8,7 @@
 :glob:
 :maxdepth: 2
 
+pre-requisites
 *
 ```
 

--- a/docs/nixos-services/user-guides/index.md
+++ b/docs/nixos-services/user-guides/index.md
@@ -8,7 +8,7 @@
 :glob:
 :maxdepth: 2
 
-pre-requisites
+prerequisites
 *
 ```
 

--- a/docs/nixos-services/user-guides/ioc-services.md
+++ b/docs/nixos-services/user-guides/ioc-services.md
@@ -3,8 +3,10 @@
 This guide covers how to install EPICS IOCs as a systemd service
 on a NixOS machine.
 
-```{include} ./pre-requisites.md
-```
+:::{important}
+Make sure to follow the NixOS {doc}`pre-requisites`.
+:::
+
 
 ## Exposing a service from your IOC
 

--- a/docs/nixos-services/user-guides/ioc-services.md
+++ b/docs/nixos-services/user-guides/ioc-services.md
@@ -4,7 +4,7 @@ This guide covers how to install EPICS IOCs as a systemd service
 on a NixOS machine.
 
 :::{important}
-Make sure to follow the NixOS {doc}`pre-requisites`.
+Make sure to follow the NixOS {doc}`prerequisites`.
 :::
 
 

--- a/docs/nixos-services/user-guides/phoebus-alarm.md
+++ b/docs/nixos-services/user-guides/phoebus-alarm.md
@@ -17,8 +17,9 @@ examine the official documentation:
 
 The Phoebus Alarm Logging Service can also be called the Phoebus Alarm Logger.
 
-```{include} ./pre-requisites.md
-```
+:::{important}
+Make sure to follow the NixOS {doc}`pre-requisites`.
+:::
 
 ## Single server Phoebus Alarm setup
 

--- a/docs/nixos-services/user-guides/phoebus-alarm.md
+++ b/docs/nixos-services/user-guides/phoebus-alarm.md
@@ -18,7 +18,7 @@ examine the official documentation:
 The Phoebus Alarm Logging Service can also be called the Phoebus Alarm Logger.
 
 :::{important}
-Make sure to follow the NixOS {doc}`pre-requisites`.
+Make sure to follow the NixOS {doc}`prerequisites`.
 :::
 
 ## Single server Phoebus Alarm setup

--- a/docs/nixos-services/user-guides/phoebus-client.md
+++ b/docs/nixos-services/user-guides/phoebus-client.md
@@ -7,6 +7,10 @@ such as the ones in the particle accelerator community.
 You can install the Phoebus client by using {nix:option}`programs.phoebus-client.enable`,
 and configure it by using the other options in {nix:option}`programs.phoebus-client`.
 
+:::{important}
+Make sure to follow the NixOS {doc}`pre-requisites`.
+:::
+
 ## Configure the preference settings
 
 ### By specifying settings

--- a/docs/nixos-services/user-guides/phoebus-client.md
+++ b/docs/nixos-services/user-guides/phoebus-client.md
@@ -8,7 +8,7 @@ You can install the Phoebus client by using {nix:option}`programs.phoebus-client
 and configure it by using the other options in {nix:option}`programs.phoebus-client`.
 
 :::{important}
-Make sure to follow the NixOS {doc}`pre-requisites`.
+Make sure to follow the NixOS {doc}`prerequisites`.
 :::
 
 ## Configure the preference settings

--- a/docs/nixos-services/user-guides/phoebus-save-and-restore.md
+++ b/docs/nixos-services/user-guides/phoebus-save-and-restore.md
@@ -10,7 +10,7 @@ For more details and documentation about Phoebus save-and-restore,
 you can examine the [save-and-restore official documentation].
 
 :::{important}
-Make sure to follow the NixOS {doc}`pre-requisites`.
+Make sure to follow the NixOS {doc}`prerequisites`.
 :::
 
 ## Enabling the Phoebus save-and-restore service

--- a/docs/nixos-services/user-guides/phoebus-save-and-restore.md
+++ b/docs/nixos-services/user-guides/phoebus-save-and-restore.md
@@ -9,8 +9,9 @@ This guide focuses on installing and configuring the save-and-restore service on
 For more details and documentation about Phoebus save-and-restore,
 you can examine the [save-and-restore official documentation].
 
-```{include} ./pre-requisites.md
-```
+:::{important}
+Make sure to follow the NixOS {doc}`pre-requisites`.
+:::
 
 ## Enabling the Phoebus save-and-restore service
 

--- a/docs/nixos-services/user-guides/pre-requisites.md
+++ b/docs/nixos-services/user-guides/pre-requisites.md
@@ -1,6 +1,8 @@
-## Pre-requisites
+# Pre-requisites
 
-- Having a NixOS machine with a flake configuration.
+## NixOS flake
+
+One prerequisite is having a NixOS machine with a flake configuration.
 
 If you’re not sure how to do this,
 you can follow the {doc}`../tutorials/archiver-appliance` tutorial,

--- a/docs/nixos-services/user-guides/prerequisites.md
+++ b/docs/nixos-services/user-guides/prerequisites.md
@@ -45,3 +45,12 @@ For example:
    };
  }
 ```
+
+## Hostname consistency
+
+In your {file}`flake.nix`,
+you should see the line {samp}`nixosConfigurations.{hostname} = ...`.
+
+Make sure the specified _hostname_ is consistent
+with the machine's hostname,
+which is defined by the option `networking.hostName`.

--- a/docs/nixos-services/user-guides/prerequisites.md
+++ b/docs/nixos-services/user-guides/prerequisites.md
@@ -1,4 +1,4 @@
-# Pre-requisites
+# Prerequisites
 
 ## NixOS flake
 

--- a/docs/nixos-services/user-guides/prerequisites.md
+++ b/docs/nixos-services/user-guides/prerequisites.md
@@ -1,5 +1,9 @@
 # Prerequisites
 
+## Global prerequisites
+
+Make sure to follow EPNix' global {doc}`../../prerequisites`.
+
 ## NixOS flake
 
 One prerequisite is having a NixOS machine with a flake configuration.

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,4 +1,4 @@
-# Pre-requisites
+# Prerequisites
 
 The requirements for using EPNix are having curl, Nix, and Git installed,
 either in a Linux system,

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -2,3 +2,5 @@
 "development/explanations/packaging-policy.md" "contributing/explanations/packaging-policy.md"
 "development/guides/index.md" "contributing/guides/index.md"
 "development/guides/release-process.md" "contributing/guides/release-process.md"
+"pre-requisites.md" "prerequisites.md"
+"nixos-services/user-guides/pre-requisites.md" "nixos-services/user-guides/prerequisites.md"


### PR DESCRIPTION
- Rename "pre-requisites" to "prerequisites", because it's the correct word!
- Make the NixOS prerequisites its own, up front page
- Mention that the hostname must be consistent in the NixOS prerequisites

Fixes #403