### PR TITLE
phoebus-unwrapped: don't use deprecated substituteAll

### DIFF
--- a/pkgs/by-name/phoebus-unwrapped/package.nix
+++ b/pkgs/by-name/phoebus-unwrapped/package.nix
@@ -2,7 +2,7 @@
   lib,
   epnixLib,
   stdenv,
-  substituteAll,
+  replaceVars,
   maven,
   makeWrapper,
   jdk21,
@@ -19,8 +19,7 @@ stdenv.mkDerivation {
   inherit (phoebus-deps) version src;
 
   patches = [
-    (substituteAll {
-      src = ./fix-python-path.patch;
+    (replaceVars ./fix-python-path.patch {
       python = lib.getExe python3;
     })
   ];


### PR DESCRIPTION
Replace with new function `replaceVars`.

CC @Rider128 