### PR TITLE
mkEpicsPackage: use extendMkDerivation

### DIFF
--- a/docs/contributing/tutorials/packaging-asyn.md
+++ b/docs/contributing/tutorials/packaging-asyn.md
@@ -41,8 +41,6 @@ with the following template content:
 {
   epnixLib,
   mkEpicsPackage,
-  local_config_site ? { },
-  local_release ? { },
 }:
 mkEpicsPackage {
   pname = "TODO";
@@ -50,8 +48,6 @@ mkEpicsPackage {
   varname = "TODO";
 
   src = TODO;
-
-  inherit local_config_site local_release;
 
   # For EPICS, native libraries need to be in both
   # nativeBuildInputs and buildInputs
@@ -144,8 +140,6 @@ your package file should look like this:
 {
   epnixLib,
   mkEpicsPackage,
-  local_config_site ? { },
-  local_release ? { },
 }:
 mkEpicsPackage {
   pname = "my-asyn";
@@ -153,8 +147,6 @@ mkEpicsPackage {
   varname = "MY_ASYN";
 
   src = TODO;
-
-  inherit local_config_site local_release;
 
   # For EPICS, native libraries need to be in both
   # nativeBuildInputs and buildInputs
@@ -195,8 +187,6 @@ which you can use like this:
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
-  local_config_site ? { },
-  local_release ? { },
 }:
 mkEpicsPackage {
   pname = "my-asyn";
@@ -209,8 +199,6 @@ mkEpicsPackage {
     tag = "R4-45";
     hash = "";
   };
-
-  inherit local_config_site local_release;
 
   # For EPICS, native libraries need to be in both
   # nativeBuildInputs and buildInputs
@@ -361,8 +349,6 @@ edit your package file as follows:
   calc,
   ipac,
   seq,
-  local_config_site ? { },
-  local_release ? { },
 }:
 mkEpicsPackage {
   # ...
@@ -455,8 +441,6 @@ Edit your package as follows:
   calc,
   ipac,
   seq,
-  local_config_site ? { },
-  local_release ? { },
 }:
 mkEpicsPackage {
   # ...
@@ -617,8 +601,6 @@ native libraries go into both `nativeBuildInputs` and `buildInputs`.
   calc,
   ipac,
   seq,
-  local_config_site ? { },
-  local_release ? { },
 }:
 mkEpicsPackage {
   # ...
@@ -663,7 +645,7 @@ mkEpicsPackage {
   # ...
 
   inherit local_release;
-  local_config_site = local_config_site // {
+  local_config_site = {
     TIRPC = "YES";
   };
 
@@ -785,8 +767,6 @@ it goes into `nativeBuildInputs`.
   calc,
   ipac,
   seq,
-  local_config_site ? { },
-  local_release ? { },
 }:
 mkEpicsPackage {
   # ...

--- a/docs/contributing/tutorials/packaging-asyn/my-asyn/package.nix
+++ b/docs/contributing/tutorials/packaging-asyn/my-asyn/package.nix
@@ -9,8 +9,6 @@
   ipac,
   seq,
   sscan,
-  local_config_site ? { },
-  local_release ? { },
 }:
 mkEpicsPackage {
   pname = "my-asyn";
@@ -26,8 +24,7 @@ mkEpicsPackage {
 
   patches = [ ./use-pkg-config.patch ];
 
-  inherit local_release;
-  local_config_site = local_config_site // {
+  local_config_site = {
     TIRPC = "YES";
   };
 

--- a/docs/release-notes/2605.md
+++ b/docs/release-notes/2605.md
@@ -74,6 +74,30 @@
 
 - The {option}`services.phoebus-olog` module gained an `openFirewall` option.
 
+- You can now pass a function
+  as argument to the `mkEpicsPackage` function.
+  This means that you can use the [`finalAttrs` pattern],
+  for example:
+
+  ```nix
+  # ...
+  mkEpicsPackage (finalAttrs: {
+    pname = "my-package";
+    version = "1.0.0";
+
+    src = fetchFromGitHub {
+      owner = "my-owner";
+      repo = "my-repo";
+      rev = finalAttrs.version;
+      hash = "...";
+    };
+
+    # ...
+  })
+  ```
+
+  [`finalAttrs` pattern]: https://nixos.org/manual/nixpkgs/stable/#mkderivation-recursive-attributes
+
 ## Fixes
 
 - spring-boot based services

--- a/pkgs/by-name/ca-gateway/package.nix
+++ b/pkgs/by-name/ca-gateway/package.nix
@@ -5,15 +5,15 @@
   python3Packages,
   pcas,
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "ca-gateway";
   version = "2.1.3";
   varname = "CA_GATEWAY";
 
   src = fetchFromGitHub {
     owner = "epics-extensions";
-    repo = pname;
-    rev = "v${version}";
+    repo = finalAttrs.pname;
+    tag = "v${finalAttrs.version}";
     hash = "sha256-PUe/MPvmBUFOKsrgIZvz65K1/HhD/ugmldKGY6SnMck=";
   };
 
@@ -30,4 +30,4 @@ mkEpicsPackage rec {
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/by-name/epicsSetupHook/epics-setup-hook.sh
+++ b/pkgs/by-name/epicsSetupHook/epics-setup-hook.sh
@@ -31,13 +31,13 @@ epicsConfigurePhase() {
 		echo 'CROSS_COMPILER_TARGET_ARCHS="@host_arch@"' >>configure/CONFIG_SITE.local
 	fi
 
-	echo "${local_config_site-}" >>configure/CONFIG_SITE.local
+	echo "${local_config_site_text-}" >>configure/CONFIG_SITE.local
 
 	# Undefine the SUPPORT variable here, since there is no single "support"
 	# directory and this variable is a source of conflicts between RELEASE files
 	echo "undefine SUPPORT" >configure/RELEASE.local
 
-	echo "${local_release-}" >>configure/RELEASE.local
+	echo "${local_release_text-}" >>configure/RELEASE.local
 
 	# set to empty if unset
 	: "''${EPICS_COMPONENTS=}"

--- a/pkgs/by-name/mkEpicsPackage/package.nix
+++ b/pkgs/by-name/mkEpicsPackage/package.nix
@@ -8,73 +8,90 @@
   readline,
   ...
 }:
-{
-  pname,
-  varname,
-  epics-base ? epnix.epics-base,
-  local_config_site ? { },
-  local_release ? { },
-  isEpicsBase ? false,
-  depsBuildBuild ? [ ],
-  nativeBuildInputs ? [ ],
-  buildInputs ? [ ],
-  shellHook ? "",
-  ...
-}@attrs:
+
 let
-  # remove non standard attributes that cannot be coerced to strings
-  overridable = builtins.removeAttrs attrs [
-    "local_config_site"
-    "local_release"
-  ];
   generateConf = (buildPackages.epnixLib.formats.make { }).generate;
 in
-stdenv.mkDerivation (
-  overridable
-  // {
-    strictDeps = true;
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+  excludeDrvArgNames = [ "isEpicsBase" ];
+  extendDrvArgs =
+    finalAttrs:
+    {
+      varname,
+      epics-base ? epnix.epics-base,
+      local_config_site ? { },
+      local_release ? { },
+      isEpicsBase ? false,
 
-    # When cross-compiling,
-    # epics will build every project twice,
-    # once "build -> build", and once "build -> host",
-    # so we need a compiler for the "build -> build" compilation.
-    depsBuildBuild = depsBuildBuild ++ [ buildPackages.stdenv.cc ];
+      depsBuildBuild ? [ ],
+      nativeBuildInputs ? [ ],
+      buildInputs ? [ ],
+      shellHook ? "",
+      ...
+    }@attrs:
+    let
+      varname' = finalAttrs.varname or varname;
+      epics-base' = finalAttrs.epics-base or epics-base;
+      local_config_site' = finalAttrs.local_config_site or local_config_site;
+      local_release' = finalAttrs.local_release or local_release;
+    in
+    {
+      __structuredAttrs = true;
 
-    nativeBuildInputs = nativeBuildInputs ++ [
-      makeWrapper
-      perl
-      readline
-      epnix.epicsSetupHook
-    ];
+      strictDeps = true;
 
-    # Also add perl into the non-native build inputs
-    # so that shebangs gets patched
-    buildInputs =
-      buildInputs
-      ++ [
+      # When cross-compiling,
+      # epics will build every project twice,
+      # once "build -> build", and once "build -> host",
+      # so we need a compiler for the "build -> build" compilation.
+      depsBuildBuild = depsBuildBuild ++ [ buildPackages.stdenv.cc ];
+
+      nativeBuildInputs = nativeBuildInputs ++ [
+        makeWrapper
         perl
         readline
-      ]
-      ++ (lib.optional (!isEpicsBase) epics-base);
+        epnix.epicsSetupHook
+      ];
 
-    setupHook = ./setup-hook.sh;
+      # Also add perl into the non-native build inputs
+      # so that shebangs gets patched
+      buildInputs =
+        buildInputs
+        ++ [
+          perl
+          readline
+        ]
+        ++ (lib.optional (!isEpicsBase) epics-base');
 
-    local_config_site = generateConf local_config_site;
-    local_release = generateConf local_release;
+      setupHook = ./setup-hook.sh;
 
-    doCheck = attrs.doCheck or true;
-    checkTarget = "runtests";
+      local_config_site_text = generateConf local_config_site';
+      local_release_text = generateConf local_release';
 
-    shellHook = ''
-      ${lib.optionalString (!isEpicsBase) ''
-        # epics-base is considered a "buildInputs",
-        # not a "nativeBuildInputs",
-        # so it needs to be manually added in to the PATH
-        # in a development shell,
-        addToSearchPath PATH "${epics-base}/bin"
-      ''}
+      env = {
+        # Make sure to put the `varname` inside `env`,
+        # else it doesn't get exported
+        # and the `setupHook` can't see it.
+        # It can't also be named `varname`,
+        # since it will clash with the `varname` passed
+        # to the toplevel derivation arguments.
+        component_varname = varname';
+      };
 
-      ${shellHook}
-    '';
-  }
-)
+      doCheck = attrs.doCheck or true;
+      checkTarget = "runtests";
+
+      shellHook = ''
+        ${lib.optionalString (!isEpicsBase) ''
+          # epics-base is considered a "buildInputs",
+          # not a "nativeBuildInputs",
+          # so it needs to be manually added in to the PATH
+          # in a development shell,
+          addToSearchPath PATH "${epics-base'}/bin"
+        ''}
+
+        ${shellHook}
+      '';
+    };
+}

--- a/pkgs/by-name/mkEpicsPackage/setup-hook.sh
+++ b/pkgs/by-name/mkEpicsPackage/setup-hook.sh
@@ -2,4 +2,4 @@
 # so that we are able to list every EPICS-specific packages,
 # to add them in the 'configure/RELEASE.local' file
 # in dependent packages.
-export "EPICS_COMPONENTS=${EPICS_COMPONENTS:+${EPICS_COMPONENTS}:}@varname@=@out@"
+export "EPICS_COMPONENTS=${EPICS_COMPONENTS:+${EPICS_COMPONENTS}:}@component_varname@=@out@"

--- a/pkgs/by-name/pcas/package.nix
+++ b/pkgs/by-name/pcas/package.nix
@@ -3,15 +3,15 @@
   mkEpicsPackage,
   fetchFromGitHub,
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "pcas";
   version = "4.13.3";
   varname = "PCAS";
 
   src = fetchFromGitHub {
     owner = "epics-modules";
-    repo = pname;
-    rev = "v${version}";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
     hash = "sha256-wwU2/4CHI/dExqfFL1AzK7d+cMRGU1oxSlhb/3xY7xs=";
   };
 
@@ -21,4 +21,4 @@ mkEpicsPackage rec {
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/by-name/procServ/package.nix
+++ b/pkgs/by-name/procServ/package.nix
@@ -5,14 +5,14 @@
   autoreconfHook,
   epnixLib,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "procServ";
   version = "2.8.0";
 
   src = fetchFromGitHub {
     owner = "ralphlange";
-    repo = pname;
-    rev = "v${version}";
+    repo = finalAttrs.pname;
+    tag = "v${finalAttrs.version}";
     hash = "sha256-MVifC4mq8tM71YpXFu0u0fGwq6vtbK/jofCJShjfq3Q=";
   };
 
@@ -31,4 +31,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/python-modules/by-name/pvapy/package.nix
+++ b/pkgs/python-modules/by-name/pvapy/package.nix
@@ -40,153 +40,155 @@ let
     enableNumpy = true;
   };
 in
-toPythonModule (mkEpicsPackage rec {
-  pname = "pvapy";
-  version = "5.6.0";
-  varname = "PVAPY";
+toPythonModule (
+  mkEpicsPackage (finalAttrs: {
+    pname = "pvapy";
+    version = "5.6.0";
+    varname = "PVAPY";
 
-  outputs = [
-    "out"
-    "dist"
-  ];
-
-  src = fetchFromGitHub {
-    owner = "epics-base";
-    repo = "pvaPy";
-    tag = version;
-    hash = "sha256-YbL3nkqTkzJ2fTfiESXE/NWT1OJeDPrMBNTKFiamAi4=";
-  };
-
-  patches = [
-    # Upstream's `setup.py` tries to build everything build itself,
-    # including downloading dependencies.
-    # Here we compile things ourselves using the EPICS build facility,
-    # then install the Python parts using the `pypa` hooks.
-    ./dont-build-with-setup-py.patch
-
-    (replaceVars ./replace-versions.patch { inherit version; })
-  ];
-
-  nativeBuildInputs = [
-    autoconf
-    automake
-    which
-
-    python
-    distutils
-    setuptools
-    sphinx-rtd-theme
-
-    pypaBuildHook
-    pypaInstallHook
-    pythonImportsCheckHook
-    pythonOutputDistHook
-    pythonRecompileBytecodeHook
-    sphinxHook
-    wrapPython
-  ];
-
-  buildInputs = [
-    boost'
-    python
-  ]
-  # Needed for building the Sphinx documentation
-  ++ passthru.optional-dependencies.all;
-
-  propagatedBuildInputs = [
-    numpy
-  ];
-
-  postConfigure = ''
-    make configure \
-      BOOST_INCLUDE_DIR=${lib.getDev boost'}/include \
-      BOOST_DIR=${boost'} \
-      BOOST_LIB_DIR=${boost'}/lib \
-      BOOST_PYTHON_NUMPY_DIR=${boost'}/lib \
-      BOOST_NUMPY_DIR=${boost'}/lib \
-      EPICS_BASE=${epnix.epics-base} \
-      EPICS_HOST_ARCH=${epnixLib.toEpicsArch stdenv.buildPlatform}
-  '';
-
-  # We still need to use the "standard" EPICS build,
-  # so we have to let the default `mkEpicsPackage` build phase run.
-  dontUsePypaBuild = true;
-
-  # Some of these instructions are inspired
-  # by what's in `tools/pip/pvapy-pip/build.linux.sh`
-  postBuild = ''
-    # `pvaPy` installs the `pvaccess` library into $out/lib/python/VERSION/ARCH/*
-    # instead of the dir read by Python before installing
-    cp -a $out/lib/python/*/*/* tools/build/pvaccess
-
-    # Make the Python dirs visible to the `pypa` build phase
-    cp -r tools/build/pvaccess pvapy tools/pip/pvapy-pip
-
-    pushd tools/pip/pvapy-pip
-    export PVAPY_VERSION=${version}
-    # Temporarily unset postBuild to avoid an infinite loop
-    postBuild=":" pypaBuildPhase
-    popd
-
-    # Copy the dist folder to the source root,
-    # so that the `pypa` install hook can find it.
-    cp -r tools/pip/pvapy-pip/dist .
-  '';
-
-  postInstall = ''
-    # Remove the `pvaccess.so` manually installed by the EPICS build system
-    # it was already copied to the Python package.
-    rm -rf $out/lib/python
-  '';
-
-  sphinxRoot = "documentation/sphinx";
-  postInstallSphinx = ''
-    pushd documentation
-    cp -r *.md images presentations $out/share/doc/*/
-    popd
-    cp LICENSE $out/share/doc/*/
-  '';
-
-  pythonImportsCheck = [
-    "pvaccess"
-    "pvapy"
-  ];
-
-  postFixup = ''
-    wrapPythonPrograms
-  '';
-
-  passthru.optional-dependencies = {
-    image-processing = [
-      pillow
-      h5py
-      hdf5plugin
+    outputs = [
+      "out"
+      "dist"
     ];
-    encryption = [
-      pycryptodome
-      rsa
-    ];
-    blosc-compression = [ blosc ];
-    lz4-compression = [ lz4 ];
-    bslz4-compression = [ bitshuffle ];
-    all = [
-      pillow
-      h5py
-      hdf5plugin
-      pycryptodome
-      rsa
-      blosc
-      lz4
-      bitshuffle
-    ];
-  };
 
-  meta = {
-    description = "PvaPy provides Python bindings for EPICS pvAccess";
-    homepage = "https://github.com/epics-base/pvaPy/";
-    license = epnixLib.licenses.epics;
-    maintainers = with epnixLib.maintainers; [ minijackson ];
-    mainProgram = "pvapy";
-    platforms = lib.platforms.all;
-  };
-})
+    src = fetchFromGitHub {
+      owner = "epics-base";
+      repo = "pvaPy";
+      tag = finalAttrs.version;
+      hash = "sha256-YbL3nkqTkzJ2fTfiESXE/NWT1OJeDPrMBNTKFiamAi4=";
+    };
+
+    patches = [
+      # Upstream's `setup.py` tries to build everything build itself,
+      # including downloading dependencies.
+      # Here we compile things ourselves using the EPICS build facility,
+      # then install the Python parts using the `pypa` hooks.
+      ./dont-build-with-setup-py.patch
+
+      (replaceVars ./replace-versions.patch { inherit (finalAttrs) version; })
+    ];
+
+    nativeBuildInputs = [
+      autoconf
+      automake
+      which
+
+      python
+      distutils
+      setuptools
+      sphinx-rtd-theme
+
+      pypaBuildHook
+      pypaInstallHook
+      pythonImportsCheckHook
+      pythonOutputDistHook
+      pythonRecompileBytecodeHook
+      sphinxHook
+      wrapPython
+    ];
+
+    buildInputs = [
+      boost'
+      python
+    ]
+    # Needed for building the Sphinx documentation
+    ++ finalAttrs.passthru.optional-dependencies.all;
+
+    propagatedBuildInputs = [
+      numpy
+    ];
+
+    postConfigure = ''
+      make configure \
+        BOOST_INCLUDE_DIR=${lib.getDev boost'}/include \
+        BOOST_DIR=${boost'} \
+        BOOST_LIB_DIR=${boost'}/lib \
+        BOOST_PYTHON_NUMPY_DIR=${boost'}/lib \
+        BOOST_NUMPY_DIR=${boost'}/lib \
+        EPICS_BASE=${epnix.epics-base} \
+        EPICS_HOST_ARCH=${epnixLib.toEpicsArch stdenv.buildPlatform}
+    '';
+
+    # We still need to use the "standard" EPICS build,
+    # so we have to let the default `mkEpicsPackage` build phase run.
+    dontUsePypaBuild = true;
+
+    # Some of these instructions are inspired
+    # by what's in `tools/pip/pvapy-pip/build.linux.sh`
+    postBuild = ''
+      # `pvaPy` installs the `pvaccess` library into $out/lib/python/VERSION/ARCH/*
+      # instead of the dir read by Python before installing
+      cp -a $out/lib/python/*/*/* tools/build/pvaccess
+
+      # Make the Python dirs visible to the `pypa` build phase
+      cp -r tools/build/pvaccess pvapy tools/pip/pvapy-pip
+
+      pushd tools/pip/pvapy-pip
+      export PVAPY_VERSION=${finalAttrs.version}
+      # Temporarily unset postBuild to avoid an infinite loop
+      postBuild=":" pypaBuildPhase
+      popd
+
+      # Copy the dist folder to the source root,
+      # so that the `pypa` install hook can find it.
+      cp -r tools/pip/pvapy-pip/dist .
+    '';
+
+    postInstall = ''
+      # Remove the `pvaccess.so` manually installed by the EPICS build system
+      # it was already copied to the Python package.
+      rm -rf $out/lib/python
+    '';
+
+    sphinxRoot = "documentation/sphinx";
+    postInstallSphinx = ''
+      pushd documentation
+      cp -r *.md images presentations $out/share/doc/*/
+      popd
+      cp LICENSE $out/share/doc/*/
+    '';
+
+    pythonImportsCheck = [
+      "pvaccess"
+      "pvapy"
+    ];
+
+    postFixup = ''
+      wrapPythonPrograms
+    '';
+
+    passthru.optional-dependencies = {
+      image-processing = [
+        pillow
+        h5py
+        hdf5plugin
+      ];
+      encryption = [
+        pycryptodome
+        rsa
+      ];
+      blosc-compression = [ blosc ];
+      lz4-compression = [ lz4 ];
+      bslz4-compression = [ bitshuffle ];
+      all = [
+        pillow
+        h5py
+        hdf5plugin
+        pycryptodome
+        rsa
+        blosc
+        lz4
+        bitshuffle
+      ];
+    };
+
+    meta = {
+      description = "PvaPy provides Python bindings for EPICS pvAccess";
+      homepage = "https://github.com/epics-base/pvaPy/";
+      license = epnixLib.licenses.epics;
+      maintainers = with epnixLib.maintainers; [ minijackson ];
+      mainProgram = "pvapy";
+      platforms = lib.platforms.all;
+    };
+  })
+)

--- a/pkgs/support/by-name/StreamDevice/package.nix
+++ b/pkgs/support/by-name/StreamDevice/package.nix
@@ -7,21 +7,16 @@
   calc,
   pcre,
   sscan,
-  local_config_site ? { },
-  local_release ? { },
 }:
-let
-  version = "2.8.26";
-in
-mkEpicsPackage {
+mkEpicsPackage (finalAttrs: {
   pname = "StreamDevice";
-  inherit version;
+  version = "2.8.26";
   varname = "STREAM";
 
   src = fetchFromGitHub {
     owner = "paulscherrerinstitute";
     repo = "StreamDevice";
-    rev = version;
+    tag = finalAttrs.version;
     # Tarball from GitHub is not completely reproducible due to usage of
     # export-subst in .gitattributes for .VERSION
     # See: https://epics.anl.gov/tech-talk/2022/msg01842.php
@@ -39,8 +34,7 @@ mkEpicsPackage {
     calc
   ];
 
-  inherit local_config_site;
-  local_release = local_release // {
+  local_release = {
     PCRE = null;
     PCRE_INCLUDE = "${lib.getDev pcre}/include";
     PCRE_LIB = "${lib.getLib pcre}/lib";
@@ -55,4 +49,4 @@ mkEpicsPackage {
     license = lib.licenses.lgpl3Plus;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/adsDriver/package.nix
+++ b/pkgs/support/by-name/adsDriver/package.nix
@@ -7,7 +7,7 @@
   epnixLib,
   lib,
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "adsDriver";
   version = "3.1.0";
 
@@ -15,8 +15,8 @@ mkEpicsPackage rec {
 
   src = fetchFromGitHub {
     owner = "Cosylab";
-    repo = pname;
-    rev = "v${version}";
+    repo = "adsDriver";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-Ruzi+H8MmIgv23pzFXZlvkk3HtbDzQ9LTTVzmeGWrSI==";
   };
@@ -34,4 +34,4 @@ mkEpicsPackage rec {
     license = lib.licenses.mit;
     maintainers = with epnixLib.maintainers; [ synthetica ];
   };
-}
+})

--- a/pkgs/support/by-name/asyn/package.nix
+++ b/pkgs/support/by-name/asyn/package.nix
@@ -7,28 +7,22 @@
   libtirpc,
   ipac,
   seq,
-  local_config_site ? { },
-  local_release ? { },
 }:
-let
-  version = "4-45";
-in
-mkEpicsPackage {
+mkEpicsPackage (finalAttrs: {
   pname = "asyn";
-  inherit version;
+  version = "4-45";
   varname = "ASYN";
 
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "asyn";
-    tag = "R${version}";
+    tag = "R${finalAttrs.version}";
     hash = "sha256-VOHgDuRSj3dUmCWX+nyCf/i+VNGpC0ZsyIP0qBUG0vw=";
   };
 
   patches = [ ./use-pkg-config.patch ];
 
-  inherit local_release;
-  local_config_site = local_config_site // {
+  local_config_site = {
     TIRPC = "YES";
   };
 
@@ -53,4 +47,4 @@ mkEpicsPackage {
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/autoparamDriver/package.nix
+++ b/pkgs/support/by-name/autoparamDriver/package.nix
@@ -5,7 +5,7 @@
   epnixLib,
   asyn,
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "autoparamDriver";
   version = "2.0.0";
 
@@ -13,8 +13,8 @@ mkEpicsPackage rec {
 
   src = fetchFromGitHub {
     owner = "Cosylab";
-    repo = pname;
-    rev = "v${version}";
+    repo = "autoparamDriver";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-J2fy/pMwrbwVFULfANuJBl6iE3wju5bQkhkxxk8zRYs=";
   };
 
@@ -26,4 +26,4 @@ mkEpicsPackage rec {
     license = lib.licenses.mit;
     maintainers = with epnixLib.maintainers; [ synthetica ];
   };
-}
+})

--- a/pkgs/support/by-name/autosave/package.nix
+++ b/pkgs/support/by-name/autosave/package.nix
@@ -2,27 +2,23 @@
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "autosave";
   version = "5-11";
   varname = "AUTOSAVE";
 
-  inherit local_config_site local_release;
-
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "autosave";
-    rev = "R${version}";
-    sha256 = "sha256-T6b2SUxgh2l+F4Vi3oF1aaLIjghlg34tLlwJOgGceLQ=";
+    tag = "R${finalAttrs.version}";
+    hash = "sha256-T6b2SUxgh2l+F4Vi3oF1aaLIjghlg34tLlwJOgGceLQ=";
   };
 
   meta = {
     description = "Module that automatically saves values of EPICS PVs to files, and restores those values when the IOC is restarted.";
-    homepage = "https://github.com/epics-modules/autosave";
+    inherit (finalAttrs.src.meta) homepage;
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ stephane ];
   };
-}
+})

--- a/pkgs/support/by-name/busy/package.nix
+++ b/pkgs/support/by-name/busy/package.nix
@@ -5,21 +5,17 @@
   asyn,
   autosave,
   calc,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "busy";
   version = "1-7-4";
   varname = "BUSY";
 
-  inherit local_config_site local_release;
-
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "busy";
-    rev = "R${version}";
-    sha256 = "sha256-mSzFLj42iXkyWGWaxplfLehoQcULLpf745trYMd1XT4=";
+    tag = "R${finalAttrs.version}";
+    hash = "sha256-mSzFLj42iXkyWGWaxplfLehoQcULLpf745trYMd1XT4=";
   };
 
   patches = [ ./fix-release.patch ];
@@ -36,4 +32,4 @@ mkEpicsPackage rec {
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ agaget ];
   };
-}
+})

--- a/pkgs/support/by-name/calc/package.nix
+++ b/pkgs/support/by-name/calc/package.nix
@@ -3,10 +3,8 @@
   mkEpicsPackage,
   fetchFromGitHub,
   sscan,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "calc";
   version = "3-7-5";
   varname = "CALC";
@@ -14,13 +12,11 @@ mkEpicsPackage rec {
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "calc";
-    rev = "R${version}";
+    tag = "R${finalAttrs.version}";
     sha256 = "sha256-S40HtO7HXDS27u7wmlxuo7oV1abtj1EaXfIz0Kj1IM0=";
   };
 
   propagatedBuildInputs = [ sscan ];
-
-  inherit local_config_site local_release;
 
   meta = {
     description = "Support for run-time expression evaluation";
@@ -28,4 +24,4 @@ mkEpicsPackage rec {
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/devlib2/package.nix
+++ b/pkgs/support/by-name/devlib2/package.nix
@@ -1,32 +1,26 @@
 {
-  lib,
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
-  fetchpatch,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "devlib2";
   version = "2.12";
   varname = "DEVLIB2";
   #tests seems to need a PCI device to be validated.
   doCheck = false;
 
-  inherit local_config_site local_release;
-
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "devlib2";
-    rev = version;
-    sha256 = "sha256-5rjilz+FO6ZM+Hn7AVwyFG2WWBoBUQA4WW5OHhhdXw4=";
+    rev = finalAttrs.version;
+    hash = "sha256-5rjilz+FO6ZM+Hn7AVwyFG2WWBoBUQA4WW5OHhhdXw4=";
   };
 
   meta = {
-    description = "devLib2 - Library for direct MMIO access to PCI and VME64x";
-    homepage = "https://github.com/epics-modules/devlib2";
+    description = "Library for direct MMIO access to PCI and VME64x";
+    inherit (finalAttrs.src.meta) homepage;
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ agaget ];
   };
-}
+})

--- a/pkgs/support/by-name/gtest/package.nix
+++ b/pkgs/support/by-name/gtest/package.nix
@@ -1,12 +1,9 @@
 {
-  lib,
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage {
+mkEpicsPackage (finalAttrs: {
   pname = "gtest";
   version = "1.0.1";
   varname = "GTEST";
@@ -14,16 +11,14 @@ mkEpicsPackage {
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "gtest";
-    rev = "v1.0.1";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-cDZ4++AkUiOvsw4KkobyqKWLk2GzUSdDdWjLL7dr1ac=";
   };
 
-  inherit local_release local_config_site;
-
   meta = {
     description = "EPICS module to adds the Google Test and Google Mock frameworks to EPICS";
-    homepage = "https://github.com/epics-modules/gtest";
+    inherit (finalAttrs.src.meta) homepage;
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/ipac/package.nix
+++ b/pkgs/support/by-name/ipac/package.nix
@@ -3,21 +3,17 @@
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "ipac";
   version = "2.16";
   varname = "IPAC";
 
-  inherit local_config_site local_release;
-
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "ipac";
-    rev = version;
-    sha256 = "sha256-J39oJ6taVpXlDlPB2tMlAZfpXqIyNzK8hhN9ndvDIbE=";
+    tag = finalAttrs.version;
+    hash = "sha256-J39oJ6taVpXlDlPB2tMlAZfpXqIyNzK8hhN9ndvDIbE=";
   };
 
   meta = {
@@ -26,4 +22,4 @@ mkEpicsPackage rec {
     license = lib.licenses.lgpl21Plus;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/modbus/package.nix
+++ b/pkgs/support/by-name/modbus/package.nix
@@ -5,15 +5,15 @@
   fetchFromGitHub,
   asyn,
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "modbus";
   version = "3-4";
   varname = "MODBUS";
 
   src = fetchFromGitHub {
     owner = "epics-modules";
-    repo = pname;
-    rev = "R${version}";
+    repo = "modbus";
+    rev = "R${finalAttrs.version}";
     hash = "sha256-0v6eLWdjgYKbFOHWaW1NSfN/gG5XHVRD9jan55dXWW0=";
   };
 
@@ -25,4 +25,4 @@ mkEpicsPackage rec {
     license = lib.licenses.mit;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/mrfioc2/package.nix
+++ b/pkgs/support/by-name/mrfioc2/package.nix
@@ -3,29 +3,25 @@
   mkEpicsPackage,
   fetchFromGitHub,
   devlib2,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "mrfioc2";
   version = "2.7.2";
   varname = "MRFIOC2";
 
-  inherit local_config_site local_release;
-
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "mrfioc2";
-    tag = version;
-    sha256 = "sha256-AWwpv5JbnFwLMp/wku0lgI7TL0O0hqC+ycP/ypzwGbU=";
+    tag = finalAttrs.version;
+    hash = "sha256-AWwpv5JbnFwLMp/wku0lgI7TL0O0hqC+ycP/ypzwGbU=";
   };
 
   propagatedBuildInputs = [ devlib2 ];
 
   meta = {
     description = "EPICS driver for Micro Research Finland event timing system devices";
-    inherit (src.meta) homepage;
+    inherit (finalAttrs.src.meta) homepage;
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ agaget ];
   };
-}
+})

--- a/pkgs/support/by-name/opcua/package.nix
+++ b/pkgs/support/by-name/opcua/package.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
@@ -8,10 +7,8 @@
   openssl,
   libxml2,
   gtest,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage {
+mkEpicsPackage (finalAttrs: {
   pname = "opcua";
   version = "0.11.2";
   varname = "OPCUA";
@@ -19,12 +16,11 @@ mkEpicsPackage {
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "opcua";
-    rev = "v0.11.2";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-64DBRiGZRGCBeg/cpNK3LRMQ3ciAtGQiUYLNhBJWC+w=";
   };
 
-  inherit local_release;
-  local_config_site = local_config_site // {
+  local_config_site = {
     OPEN62541 = "${open62541_1_3}";
     OPEN62541_DEPLOY_MODE = "PROVIDED";
     OPEN62541_LIB_DIR = "${open62541_1_3}/lib";
@@ -56,8 +52,8 @@ mkEpicsPackage {
 
   meta = {
     description = "EPICS support for communication with OPC UA protocol";
-    homepage = "https://github.com/epics-modules/opcua";
+    inherit (finalAttrs.src.meta) homepage;
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/pvxs/package.nix
+++ b/pkgs/support/by-name/pvxs/package.nix
@@ -4,20 +4,16 @@
   mkEpicsPackage,
   fetchFromGitHub,
   libevent,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "pvxs";
   version = "1.5.0";
   varname = "PVXS";
 
-  inherit local_config_site local_release;
-
   src = fetchFromGitHub {
     owner = "epics-base";
     repo = "pvxs";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-aG/rm/ycSyViJ94vDnXMnd7WKdKQieYBb0z/QknGXc4=";
     fetchSubmodules = true;
   };
@@ -32,9 +28,9 @@ mkEpicsPackage rec {
 
   meta = {
     description = "PVA protocol client/server library and utilities";
-    homepage = "https://mdavidsaver.github.io/pvxs/";
+    homepage = "https://epics-base.github.io/pvxs/";
     changelog = "https://epics-base.github.io/pvxs/releasenotes.html";
     license = lib.licenses.bsd3;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/reccaster/package.nix
+++ b/pkgs/support/by-name/reccaster/package.nix
@@ -3,7 +3,7 @@
   mkEpicsPackage,
   fetchFromGitHub,
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "RecCaster";
   version = "1.9.2";
   varname = "RECCASTER";
@@ -11,11 +11,11 @@ mkEpicsPackage rec {
   src = fetchFromGitHub {
     owner = "ChannelFinder";
     repo = "recsync";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Iq+w0QV02tVsaVIQu+mWU4h8L0c7QXi9pB8P0nQmVmg=";
   };
 
-  sourceRoot = "${src.name}/client";
+  sourceRoot = "${finalAttrs.src.name}/client";
 
   patches = [ ./fix-example-shebang.patch ];
 
@@ -25,4 +25,4 @@ mkEpicsPackage rec {
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/seq/package.nix
+++ b/pkgs/support/by-name/seq/package.nix
@@ -3,15 +3,11 @@
   mkEpicsPackage,
   fetchdarcs,
   re2c,
-  local_config_site ? { },
-  local_release ? { },
 }:
 mkEpicsPackage {
   pname = "seq";
   version = "2.2.9";
   varname = "SNCSEQ";
-
-  inherit local_config_site local_release;
 
   nativeBuildInputs = [ re2c ];
 

--- a/pkgs/support/by-name/snmp/package.nix
+++ b/pkgs/support/by-name/snmp/package.nix
@@ -3,17 +3,19 @@
   epnixLib,
   mkEpicsPackage,
   fetchzip,
-  local_config_site ? { },
-  local_release ? { },
   net-snmp,
   openssl,
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "snmp";
   version = "1.1.0.4";
   varname = "SNMP";
 
-  inherit local_config_site local_release;
+  src = fetchzip {
+    url = "https://groups.nscl.msu.edu/controls/files/epics-snmp-${finalAttrs.version}.zip";
+    hash = "sha256-POIFlyAUNh99213ez5WPe1SQjEpk43QmDLy0dX8SakM=";
+    stripRoot = false;
+  };
 
   buildInputs = [
     net-snmp
@@ -28,16 +30,10 @@ mkEpicsPackage rec {
     echo 'include $(TOP)/configure/RELEASE.local' >> configure/RELEASE
   '';
 
-  src = fetchzip {
-    url = "https://groups.nscl.msu.edu/controls/files/epics-snmp-${version}.zip";
-    sha256 = "sha256-POIFlyAUNh99213ez5WPe1SQjEpk43QmDLy0dX8SakM=";
-    stripRoot = false;
-  };
-
   meta = {
     description = "Module providing EPICS support for SNMP (Simple Network Management Protocol)";
     homepage = "https://groups.frib.msu.edu/controls/files/devSnmp.html";
     license = lib.licenses.mit;
     maintainers = with epnixLib.maintainers; [ stephane ];
   };
-}
+})

--- a/pkgs/support/by-name/sscan/package.nix
+++ b/pkgs/support/by-name/sscan/package.nix
@@ -3,24 +3,20 @@
   mkEpicsPackage,
   fetchFromGitHub,
   seq,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "sscan";
   version = "2-11-6";
   varname = "SSCAN";
 
   src = fetchFromGitHub {
     owner = "epics-modules";
-    repo = pname;
-    rev = "R${version}";
+    repo = finalAttrs.pname;
+    tag = "R${finalAttrs.version}";
     sha256 = "sha256-hrPap4FBKMD4ddMrADOeTAmsG+rLFxALibT3qsAHNsk=";
   };
 
   buildInputs = [ seq ];
-
-  inherit local_config_site local_release;
 
   meta = {
     description = "Contains the sscan record and related software for systematically moving positioners, triggering detectors, and acquiring and storing resulting data";
@@ -28,4 +24,4 @@ mkEpicsPackage rec {
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/twincat-ads/package.nix
+++ b/pkgs/support/by-name/twincat-ads/package.nix
@@ -5,20 +5,16 @@
   fetchFromGitHub,
   asyn,
   calc,
-  local_config_site ? { },
-  local_release ? { },
 }:
-mkEpicsPackage rec {
+mkEpicsPackage (finalAttrs: {
   pname = "twincat-ads";
   version = "2.1.3";
   varname = "TWINCATADS";
 
-  inherit local_config_site local_release;
-
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "twincat-ads";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-VWqvIl8d0/rKTInZyWQ0YbrRoOvmQutEfIQj3NIpSYo=";
   };
@@ -35,11 +31,11 @@ mkEpicsPackage rec {
 
   meta = {
     description = "Module providing EPICS support for ADS Protocol (Automation Device Specification)";
-    homepage = "https://github.com/epics-modules/twincat-ads/";
+    inherit (finalAttrs.src.meta) homepage;
     license = lib.licenses.lgpl3Plus;
     maintainers = with epnixLib.maintainers; [
       agaget
       minijackson
     ];
   };
-}
+})


### PR DESCRIPTION
This is the standard function to extend the `stdenv.mkDerivation` function, and allows the use of the `mkEpicsPackage (finalAttrs: ...)` pattern, which I've updated in most packages.

See here for more info about that pattern: https://nixos.org/manual/nixpkgs/stable/#mkderivation-recursive-attributes