### PR TITLE
Use headless JDK for various services

### DIFF
--- a/nixos/modules/archiver-appliance.nix
+++ b/nixos/modules/archiver-appliance.nix
@@ -295,6 +295,7 @@ in
 
     services.tomcat = {
       enable = true;
+      jdk = pkgs.jdk21_headless;
 
       # Needed to purge old configurations on upgrades,
       # such as old `commonLibs`

--- a/pkgs/by-name/archiver-appliance/package.nix
+++ b/pkgs/by-name/archiver-appliance/package.nix
@@ -3,7 +3,7 @@
   lib,
   epnixLib,
   fetchFromGitHub,
-  jdk21,
+  jdk21_headless,
   gradle,
   sphinx,
   tomcat9,
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    jdk21
+    jdk21_headless
     gradle
     sphinx
     python3Packages.myst-parser
@@ -47,7 +47,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   gradleBuildTask = "buildRelease";
   gradleFlags = [
     "-PprojVersion=${finalAttrs.version}"
-    "-Dorg.gradle.java.home=${jdk21}"
+    "-Dorg.gradle.java.home=${jdk21_headless}"
   ];
 
   # Update by running `nix build .#archiver-appliance.mitmCache.updateScript && ./result`
@@ -99,7 +99,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         psfl
       ];
     maintainers = with epnixLib.maintainers; [ minijackson ];
-    inherit (jdk21.meta) platforms;
+    inherit (jdk21_headless.meta) platforms;
     sourceProvenance = with lib.sourceTypes; [
       fromSource
       # gradle dependencies

--- a/pkgs/by-name/channel-finder-service/package.nix
+++ b/pkgs/by-name/channel-finder-service/package.nix
@@ -2,7 +2,7 @@
   lib,
   epnixLib,
   fetchFromGitHub,
-  jdk21,
+  jdk21_headless,
   maven,
   makeWrapper,
 }:
@@ -20,7 +20,7 @@ maven.buildMavenPackage rec {
   patches = [ ./support-github-archive.patch ];
 
   buildOffline = true;
-  mvnJdk = jdk21;
+  mvnJdk = jdk21_headless;
   mvnHash = "sha256-WoB97KFBJuTBIBH7gPfBYiQl3g7jA5OwVj01WstQr34=";
   mvnParameters = "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z";
 
@@ -44,7 +44,7 @@ maven.buildMavenPackage rec {
 
     install -Dm644 "target/$jarName" "$out/share/java"
 
-    makeWrapper ${lib.getExe jdk21} $out/bin/${meta.mainProgram} \
+    makeWrapper ${lib.getExe jdk21_headless} $out/bin/${meta.mainProgram} \
       --add-flags "-jar $out/share/java/$jarName"
 
     runHook postInstall
@@ -56,6 +56,6 @@ maven.buildMavenPackage rec {
     mainProgram = "channel-finder-service";
     license = lib.licenses.mit;
     maintainers = with epnixLib.maintainers; [ minijackson ];
-    inherit (jdk21.meta) platforms;
+    inherit (jdk21_headless.meta) platforms;
   };
 }

--- a/pkgs/by-name/phoebus-olog/package.nix
+++ b/pkgs/by-name/phoebus-olog/package.nix
@@ -2,7 +2,7 @@
   lib,
   epnixLib,
   fetchFromGitHub,
-  jdk21,
+  jdk21_headless,
   maven,
   makeWrapper,
 }:
@@ -17,7 +17,7 @@ maven.buildMavenPackage rec {
     hash = "sha256-5LcDBisr+uu43B3WwwzDNFNVfchuZb9shWDipgGIo2Q=";
   };
 
-  mvnJdk = jdk21;
+  mvnJdk = jdk21_headless;
   mvnHash = "sha256-6I+d6XEd6XYMZVaWyhk6YPBWAf3DnF8Xh2fDdxV7xk0=";
   mvnParameters = "-Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Pdeployable-jar";
 
@@ -33,7 +33,7 @@ maven.buildMavenPackage rec {
 
     install -Dm644 target/service-olog-${version}.jar $out/share/java
 
-    makeWrapper ${lib.getExe jdk21} $out/bin/${meta.mainProgram} \
+    makeWrapper ${lib.getExe jdk21_headless} $out/bin/${meta.mainProgram} \
       --add-flags "-jar $out/share/java/$jarName"
 
     runHook postInstall
@@ -45,6 +45,6 @@ maven.buildMavenPackage rec {
     mainProgram = "phoebus-olog";
     license = lib.licenses.epl10;
     maintainers = with epnixLib.maintainers; [ minijackson ];
-    inherit (jdk21.meta) platforms;
+    inherit (jdk21_headless.meta) platforms;
   };
 }


### PR DESCRIPTION
This makes use of the "headless" JDK, which is a JDK that doesn't depend on graphical libraries, for Phoebus Olog, the ChannelFinder service, and ArchiverAppliance.

This reduces the size of the packages, and make it coherent with other Phoebus services in EPNix, who already use the headless JDK.