### PR TITLE
Fix Phoebus embedded LDAP

### DIFF
--- a/nixos/modules/channel-finder/service.nix
+++ b/nixos/modules/channel-finder/service.nix
@@ -122,6 +122,23 @@ in
               Enable the embedded LDAP authentication.
             '';
           };
+
+          "spring.ldap.embedded.base-dn" = lib.mkOption {
+            description = ''
+              The base DN for the embedded LDAP.
+
+              :::{note}
+              Setting this value to a non-empty string
+              will start the embedded LDAP,
+              no matter the value of {nix:option}`"embedded_ldap.enabled"`,
+              which may lead to port conflicts
+              if you deploy multiple Phoebus services.
+              :::
+            '';
+            type = lib.types.str;
+            default = if cfg.settings."embedded_ldap.enabled" == "true" then "dc=cf,dc=local" else "";
+            defaultText = lib.literalExpression ''if cfg.settings."embedded_ldap.enabled" == "true" then "dc=cf,dc=local" else ""'';
+          };
         };
       };
     };

--- a/nixos/modules/phoebus/olog.nix
+++ b/nixos/modules/phoebus/olog.nix
@@ -86,6 +86,23 @@ in
               Enable the embedded LDAP authentication.
             '';
           };
+
+          "spring.ldap.embedded.base-dn" = lib.mkOption {
+            description = ''
+              The base DN for the embedded LDAP.
+
+              :::{note}
+              Setting this value to a non-empty string
+              will start the embedded LDAP,
+              no matter the value of {nix:option}`"embedded_ldap.enabled"`,
+              which may lead to port conflicts
+              if you deploy multiple Phoebus services.
+              :::
+            '';
+            type = lib.types.str;
+            default = if cfg.settings."embedded_ldap.enabled" == "true" then "dc=olog,dc=local" else "";
+            defaultText = lib.literalExpression ''if cfg.settings."embedded_ldap.enabled" == "true" then "dc=olog,dc=local" else ""'';
+          };
         };
       };
     };

--- a/nixos/modules/phoebus/save-and-restore.nix
+++ b/nixos/modules/phoebus/save-and-restore.nix
@@ -154,6 +154,23 @@ in
             default = "1234";
           };
 
+          "spring.ldap.embedded.base-dn" = lib.mkOption {
+            description = ''
+              The base DN for the embedded LDAP.
+
+              :::{note}
+              Setting this value to a non-empty string
+              will start the embedded LDAP,
+              no matter the value of {nix:option}`"auth.impl"`,
+              which may lead to port conflicts
+              if you deploy multiple Phoebus services.
+              :::
+            '';
+            type = lib.types.str;
+            default = if cfg.settings."auth.impl" == "ldap_embedded" then "dc=sar,dc=local" else "";
+            defaultText = lib.literalExpression ''if cfg.settings."auth.impl" == "ldap_embedded" then "dc=sar,dc=local" else ""'';
+          };
+
           "spring.ldap.embedded.ldif" = lib.mkOption {
             description = ''
               Path to [LDIF] file describing the content of the embedded LDAP server.


### PR DESCRIPTION
As it is today, the Embedded LDAP of Phoebus Olog, the ChannelFinder service, and the Phoebus save-and-restore service all start an embedded LDAP server, even if it's not used.

This leads to a port conflict, by default on port 8389.

We fix this by setting the `spring.ldap.embedded.base-dn` property to `""` if the user didn't configure the use of the embedded LDAP authentication method, which makes spring boot not start the embedded LDAP server.