### PR TITLE
Build Phoebus documentation

### DIFF
--- a/docs/release-notes/2605.md
+++ b/docs/release-notes/2605.md
@@ -13,6 +13,9 @@ No breaking change were introduced in this EPNix release.
   and {pkg}`epnix.support.reccaster` / {pkg}`python3Packages.recceiver` were upgraded to `1.9.2+`.
   No user-visible breaking changes.
 
+- {pkg}`epnix.phoebus` now bundles the Phoebus documentation,
+  and follows a file structure closer to what's distributed in official Phoebus packages.
+
 ## Fixes
 
 - spring-boot based services

--- a/pkgs/by-name/phoebus-unwrapped/package.nix
+++ b/pkgs/by-name/phoebus-unwrapped/package.nix
@@ -35,7 +35,14 @@ stdenv.mkDerivation {
         };
       };
     })
-  ];
+  ]
+  ++ (with python3.pkgs; [
+    sphinxHook
+    distutils
+    myst-parser
+    sphinx-rtd-theme
+    sphinxcontrib-openapi
+  ]);
 
   # Put runtime dependencies in propagated
   # because references get thrown into a jar

--- a/pkgs/by-name/phoebus/package.nix
+++ b/pkgs/by-name/phoebus/package.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation {
 
     # Settings file
     ${lib.optionalString (settingsFile != null) "ln -sfn ${settingsFile} $out/settings.ini"}
+    # Documentation
+    ln -sfn ${phoebus-unwrapped}/share/doc/${phoebus-unwrapped.name}/html $out/doc
   '';
 
   # Don't move `$out/doc` to the correct location,

--- a/pkgs/by-name/phoebus/package.nix
+++ b/pkgs/by-name/phoebus/package.nix
@@ -27,6 +27,19 @@ stdenv.mkDerivation {
   # Prevent double-wrapping
   dontWrapGApps = true;
 
+  # Install things as expected by Phoebus,
+  # see the usage of `Locations.install()` in the Phoebus repository.
+  postInstall = ''
+    mkdir $out
+
+    # Settings file
+    ${lib.optionalString (settingsFile != null) "ln -sfn ${settingsFile} $out/settings.ini"}
+  '';
+
+  # Don't move `$out/doc` to the correct location,
+  # leave it as-is.
+  forceShare = "man info";
+
   # Not install phase,
   # because it's too early for "gappsWrapperArgs" to be populated
   fixupPhase = ''
@@ -35,7 +48,7 @@ stdenv.mkDerivation {
     # This wrapper for the `phoebus-unwrapped` executable sets the `JAVA_OPTS`
     makeWrapper "${lib.getExe phoebus-unwrapped}" "$out/bin/$pname" \
       ''${gappsWrapperArgs[@]} \
-      ${lib.optionalString (settingsFile != null) ''--add-flags "-settings ${settingsFile}"''} \
+      --prefix JAVA_OPTS " " "-Dphoebus.install=$out" \
       --prefix JAVA_OPTS " " "${java_opts}"
 
     runHook postFixup


### PR DESCRIPTION
And bundle it into the package, so that the Phoebus documentation is actually deployed on site.

Note: this will lead to non-stable documentation `/nix/store/...phoebus/docs`, which will change over time…

I also changed the way the settings file is loaded. Instead of adding a `-settings` argument, I set the `phoebus.install` property, and link the `settings.ini` file there.