### PR TITLE
docs: fix some broken links

### DIFF
--- a/docs/contributing/tutorials/packaging-asyn.md
+++ b/docs/contributing/tutorials/packaging-asyn.md
@@ -122,7 +122,7 @@ more common licenses,
 it's {samp}`lib.licenses.{license}`.
 
 A list of available license names can be found
-in [Nixpkgs' lib/licenses.nix] file.
+in [Nixpkgs' licenses] file.
 
 In this tutorial,
 use `epnixLib.licenses.epics`.
@@ -848,7 +848,7 @@ to learn more about Nix packaging:
   [epnix github repository]: https://github.com/epics-extensions/EPNix/
   [Nix.dev Packaging existing software]: https://nix.dev/tutorials/packaging-existing-software
   [Nixpkgs manual]: https://nixos.org/manual/nixpkgs/stable/
-  [Nixpkgs' lib/licenses.nix]: https://github.com/NixOS/nixpkgs/blob/master/lib/licenses.nix
+  [Nixpkgs' licenses]: https://github.com/NixOS/nixpkgs/blob/master/lib/licenses/licenses.nix
   [Nixpkgs' package search]: https://search.nixos.org/packages
   [WebRTC]: https://en.wikipedia.org/wiki/WebRTC
   [working with forks]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks

--- a/docs/nixos-services/tutorials/archiver-appliance.md
+++ b/docs/nixos-services/tutorials/archiver-appliance.md
@@ -353,7 +353,7 @@ You can also configure nginx to require authentication.
 
 [archiver appliance details]: https://epicsarchiver.readthedocs.io/en/stable/developer/details.html#architecture
 [file systems nixos documentation]: https://nixos.org/manual/nixos/stable/#ch-file-systems
-[flake wiki page]: https://nixos.wiki/wiki/Flakes
+[flake wiki page]: https://wiki.nixos.org/wiki/Flakes
 [nix flake command manual]: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html
 [nixos iso file]: https://nixos.org/download/#nixos-iso
 [nixpkgs]: https://github.com/NixOS/nixpkgs


### PR DESCRIPTION
The `licenses.nix` file moved upstream, and use the official NixOS wiki