### PR TITLE
Start Phoebus alarm services after Kafka & Elasticsearch

### DIFF
--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -140,6 +140,12 @@ in
       description = "Phoebus Alarm Logger";
 
       wantedBy = [ "multi-user.target" ];
+      # If the user has installed an Elasticsearch or Kafka server,
+      # it's probably going to be using them.
+      after = [
+        "apache-kafka.service"
+        "elasticsearch.service"
+      ];
 
       environment = {
         # Weirdly not "phoebus.user"

--- a/nixos/modules/phoebus/alarm-server.nix
+++ b/nixos/modules/phoebus/alarm-server.nix
@@ -192,6 +192,9 @@ in
       description = "Phoebus Alarm Server";
 
       wantedBy = [ "multi-user.target" ];
+      # If the user has installed a Kafka server,
+      # it's probably going to be using it.
+      after = [ "apache-kafka.service" ];
 
       environment.JAVA_OPTS = "-Dphoebus.user=/var/lib/phoebus-alarm-server";
 


### PR DESCRIPTION
If they exist on the local machine, it's probably a good idea to schedule the service after them.

This should fix an issue with the `phoebus-alarm` test where `phoebus-alarm-server` would timeout trying to reach Kafka.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [x] The feature has automated tests
    - [x] Tests were run

- Documentation:
    - [x] The feature is documented
    - [x] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
