### PR TITLE
phoebus-olog: 5.1.2 -> 6.0.3, disable HTTPS, add documentation

### DIFF
--- a/docs/_vale/config/vocabularies/EPNix/accept.txt
+++ b/docs/_vale/config/vocabularies/EPNix/accept.txt
@@ -17,6 +17,7 @@ nginx
 Nix
 NixOS
 NixOps
+Olog
 OpenLDAP
 procServ
 RecCaster

--- a/docs/nixos-services/options-reference/phoebus-olog.md
+++ b/docs/nixos-services/options-reference/phoebus-olog.md
@@ -1,4 +1,8 @@
 # Phoebus Olog
 
+List of NixOS options related to the Phoebus Olog service.
+For how to use them,
+examine the {doc}`../user-guides/phoebus-olog` user guide.
+
 ```{nix:automodule} services.phoebus-olog
 ```

--- a/docs/nixos-services/user-guides/phoebus-olog.md
+++ b/docs/nixos-services/user-guides/phoebus-olog.md
@@ -1,0 +1,236 @@
+# Phoebus Olog
+
+Phoebus Olog is a service that serves as an online logbook,
+for experimental and industrial logging.
+
+You can install the Phoebus Olog service by using {nix:option}`services.phoebus-olog.enable`,
+and configure it by using the other options in {nix:option}`services.phoebus-olog`.
+
+:::{important}
+Make sure to follow the NixOS {doc}`prerequisites`.
+:::
+
+:::{important}
+The EPNix Phoebus Olog NixOS module
+configures the service to listen for HTTP connections instead of HTTPS,
+which is the opposite of default upstream.
+
+That's because the upstream HTTPS configuration's private key
+is publicly available in the Git repository,
+making it insecure.
+
+If you want an HTTPS service,
+configure a reverse proxy that forwards connections
+to the Phoebus Olog service.
+:::
+
+## Enabling the service
+
+To enable the Phoebus Olog service,
+add this to your configuration.
+
+```{code-block} nix
+:caption: {file}`phoebus-olog.nix`
+
+{
+  services.phoebus-olog = {
+    enable = true;
+    # If you want to expose your service as-is:
+    openFirewall = true;
+
+    # Choose your authentication providers,
+    # see below for a list of available providers.
+    settings.authenticationProviders = [ "XXX" ];
+  };
+
+  # Phoebus Olog needs ElasticSearch.
+  # If not already enabled elsewhere in your configuration,
+  # Enable it with the code below:
+  services.elasticsearch = {
+    enable = true;
+    package = pkgs.elasticsearch7;
+  };
+
+  # Elasticsearch, needed by Phoebus Olog, is not free software (SSPL | Elastic License).
+  # To accept the license, add the code below:
+  nixpkgs.config.allowUnfreePredicate = pkg:
+    builtins.elem (lib.getName pkg) [
+      "elasticsearch"
+    ];
+}
+```
+
+:::{seealso}
+For a complete list of options related to Phoebus Olog,
+see {nix:option}`services.phoebus-olog`.
+:::
+
+## Custom port
+
+To use a custom HTTP port,
+set the {nix:option}`services.phoebus-olog.settings."server.port"` option:
+
+```{code-block} nix
+:caption: {file}`phoebus-olog.nix` --- Set custom HTTP port
+
+{
+  services.phoebus-olog = {
+    enable = true;
+    openFirewall = true;
+
+    settings."server.port" = 1234;
+  };
+
+  # ...
+}
+```
+
+## Authentication
+
+Phoebus Olog supports multiple authentication providers,
+which can be combined:
+
+`inMemory`
+:   *Not recommended for production servers*.
+    Hard coded users and passwords.
+    Provides 2 users:
+    an administrator and a user.
+
+`embeddedLdap`
+:   At the start of the Phoebus Olog service,
+    it starts an embedded LDAP server.
+
+`ldap`
+:   For a usage with an external LDAP server.
+
+`activeDirectory`
+:   For a usage with an external Microsoft Active Directory server.
+
+:::{seealso}
+Upstream's [Authentication](https://olog.readthedocs.io/en/latest/sysadmin/guides/configuring/authentication.html) documentation.
+:::
+
+### In memory
+
+:::{caution}
+This authentication type isn't recommended for production servers.
+:::
+
+This authentication configures 2 users:
+
+- an admin `admin` with `adminPass` as password,
+- and a user `user` with `userPass` as password.
+
+To use it, set {nix:option}`services.phoebus-olog.settings.authenticationProviders` to
+`[ "inMemory" ]`:
+
+```{code-block} nix
+:caption: {file}`phoebus-olog.nix` --- Default values for in memory authentication
+
+{
+  services.phoebus-olog = {
+    enable = true;
+    # ...
+
+    settings = {
+      "authenticationProviders" = [ "inMemory" ];
+    };
+  };
+
+  # ...
+}
+```
+
+### Embedded LDAP
+
+With this authentication backend,
+Phoebus Olog starts an embedded LDAP server,
+which you can configure
+by using the {nix:option}`services.phoebus-olog.settings.embedded_ldap_ldif` option.
+
+This option must point to an [LDIF] file,
+that has the content of the LDAP database.
+
+Start by downloading the [{file}`olog.ldif`] file from the Phoebus Olog source code,
+put it next to your {file}`phoebus-olog.nix` file,
+and edit it to suit your needs.
+
+Configure Phoebus Olog to use your LDIF file:
+
+```{code-block} nix
+:caption: {file}`phoebus-olog.nix` --- Configure the embedded LDAP authentication
+
+{
+  services.phoebus-olog = {
+    enable = true;
+    # ...
+
+    settings = {
+      "authenticationProviders" = [ "embeddedLdap" ];
+      "spring.ldap.embedded.ldif" = "file://${./olog.ldif}";
+    };
+  };
+
+  # ...
+}
+```
+
+To generate a password,
+use the {command}`mkpasswd` command:
+
+```{code-block} bash
+:caption: Generate a `bcrypt`-encrypted password
+
+mkpasswd -m bcrypt
+```
+
+### External LDAP authentication
+
+:::{note}
+Configuring an fully featured LDAP server is out of scope for this guide.
+See the [OpenLDAP NixOS Wiki page]
+for how to configure an OpenLDAP server
+on NixOS.
+:::
+
+This section assumes you already have a configured LDAP server.
+This configured LDAP server can be an embedded LDAP server of another service.
+
+If you want to use your company's LDAP server,
+ask your IT team for the LDAP configuration.
+The configuration must include:
+
+- URL,
+- base DN,
+- user DN pattern,
+- group search base,
+- and group search path.
+
+Here is an example configuration:
+
+```{code-block} nix
+:caption: {file}`phoebus-olog.nix` --- Configure the external LDAP authentication
+
+{
+  services.phoebus-olog = {
+    enable = true;
+    # ...
+
+    settings = {
+      "auth.impl" = "ldap";
+
+      "ldap.urls" = "ldaps://auth.mycompany.com/dc=mycompany,dc=com";
+      "ldap.base.dn" = "dc=mycompany,dc=com";
+      "ldap.user.dn.pattern" = "uid={0},ou=People";
+      "ldap.groups.search.base" = "ou=Group";
+      "ldap.groups.search.pattern" = "(memberUid= {1})";
+    };
+  };
+
+  # ...
+}
+```
+
+  [LDIF]: https://en.wikipedia.org/wiki/LDAP_Data_Interchange_Format
+  [{file}`olog.ldif`]: https://github.com/Olog/phoebus-olog/blob/master/src/main/resources/olog.ldif
+  [OpenLDAP NixOS Wiki page]: https://wiki.nixos.org/wiki/OpenLDAP

--- a/docs/release-notes/2605.md
+++ b/docs/release-notes/2605.md
@@ -71,6 +71,8 @@
 
 - {pkg}`epnix.dbwr` was upgraded to `R1`.
 
+- The {option}`services.phoebus-olog` module gained an `openFirewall` option.
+
 ## Fixes
 
 - spring-boot based services

--- a/docs/release-notes/2605.md
+++ b/docs/release-notes/2605.md
@@ -28,6 +28,24 @@
   from {option}`services.dbwr.settings`,
   define them in {option}`services.pvws.settings` instead.
 
+- {pkg}`epnix.phoebus-olog` was upgraded to `6.0.0+`,
+  which changed the option for setting the authentication providers.
+
+  Replace the use of
+  `demo_auth.enabled`,
+  `ad.enabled`,
+  `ldap.enabled`,
+  and `embedded_ldap.enabled`
+  with {option}`services.phoebus-olog.settings.authenticationProviders` instead,
+  and set it to
+  `"inMemory"`,
+  `"activeDirectory"`,
+  `"ldap"`,
+  or `"embeddedLdap"`.
+
+  Phoebus Olog now also requires bcrypt hashed password
+  for the embedded LDAP authentication provider.
+
 ## New features and highlights
 
 - {pkg}`epnix.channel-finder-service` was upgraded to `5.0.0+`

--- a/docs/release-notes/2605.md
+++ b/docs/release-notes/2605.md
@@ -45,6 +45,7 @@
 
   Phoebus Olog now also requires bcrypt hashed password
   for the embedded LDAP authentication provider.
+  See the {doc}`../nixos-services/user-guides/phoebus-olog` guide.
 
 - The {option}`services.phoebus-olog` NixOS module
   now configures the Phoebus Olog service
@@ -91,3 +92,5 @@
 
 - The {doc}`../nixos-services/user-guides/phoebus-alarm` guide now has a section
   on how to add custom alarm scripts.
+
+- A new guide for configuring {doc}`../nixos-services/user-guides/phoebus-olog`.

--- a/docs/release-notes/2605.md
+++ b/docs/release-notes/2605.md
@@ -46,6 +46,18 @@
   Phoebus Olog now also requires bcrypt hashed password
   for the embedded LDAP authentication provider.
 
+- The {option}`services.phoebus-olog` NixOS module
+  now configures the Phoebus Olog service
+  to accept HTTP connections instead of HTTPS.
+
+  That's because the upstream HTTPS configuration's private key
+  is publicly available in the Git repository,
+  making it insecure.
+
+  If you want an HTTPS service,
+  configure a reverse proxy that forwards connections
+  to the Phoebus Olog service.
+
 ## New features and highlights
 
 - {pkg}`epnix.channel-finder-service` was upgraded to `5.0.0+`

--- a/nixos/modules/channel-finder/service.nix
+++ b/nixos/modules/channel-finder/service.nix
@@ -188,7 +188,7 @@ in
         '';
 
       serviceConfig = {
-        ExecStart = "${lib.getExe pkgs.epnix.channel-finder-service} --spring.config.location=file://${configFile}";
+        ExecStart = "${lib.getExe pkgs.epnix.channel-finder-service} --spring.config.location=classpath:/application.properties,file://${configFile}";
         Type = "exec";
         Restart = "always";
 

--- a/nixos/modules/phoebus/olog.nix
+++ b/nixos/modules/phoebus/olog.nix
@@ -14,6 +14,18 @@ in
   options.services.phoebus-olog = {
     enable = lib.mkEnableOption "the Phoebus Olog service";
 
+    openFirewall = lib.mkOption {
+      description = ''
+        Open the firewall for the Phoebus Olog service.
+
+        :::{warning}
+        This opens the firewall on all network interfaces.
+        :::
+      '';
+      type = lib.types.bool;
+      default = false;
+    };
+
     settings = lib.mkOption {
       description = ''
         Configuration for the Phoebus Olog service.
@@ -178,6 +190,10 @@ in
       enable = true;
       settings.FERRETDB_TELEMETRY = "disable";
     };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
+      (lib.toInt cfg.settings."server.port")
+    ];
   };
 
   meta.maintainers = with epnixLib.maintainers; [ minijackson ];

--- a/nixos/modules/phoebus/olog.nix
+++ b/nixos/modules/phoebus/olog.nix
@@ -46,62 +46,32 @@ in
             description = "Enable unsecure HTTP.";
           };
 
-          "demo_auth.enabled" = lib.mkOption {
-            type = lib.types.bool;
-            default = false;
-            apply = lib.boolToString;
+          "authenticationProviders" = lib.mkOption {
+            type =
+              with lib.types;
+              listOf (enum [
+                "inMemory"
+                "embeddedLdap"
+                "ldap"
+                "activeDirectory"
+              ]);
+            apply = lib.concatStringsSep ",";
             description = ''
-              Enable the demo authentication.
+              User authentication providers.
 
-              Phoebus will provide two users:
+              Multiple authentication providers can be provided,
+              which will be tried in the given order.
+
+              For the `inMemory` authentication provider,
+              two users are provided:
 
               - `admin:adminPass`
               - `user:userPass`
-            '';
-          };
 
-          "ad.enabled" = lib.mkOption {
-            type = lib.types.bool;
-            default = false;
-            apply = lib.boolToString;
-            description = ''
-              Enable authenticating to an external Active Directory server.
-            '';
-          };
+              For more information, see [upstream's authentication documentation].
 
-          "ldap.enabled" = lib.mkOption {
-            type = lib.types.bool;
-            default = false;
-            apply = lib.boolToString;
-            description = ''
-              Enable authenticating to an external LDAP server.
+                [upstream's authentication documentation]: https://olog.readthedocs.io/en/latest/sysadmin/guides/configuring/authentication.html
             '';
-          };
-
-          "embedded_ldap.enabled" = lib.mkOption {
-            type = lib.types.bool;
-            default = false;
-            apply = lib.boolToString;
-            description = ''
-              Enable the embedded LDAP authentication.
-            '';
-          };
-
-          "spring.ldap.embedded.base-dn" = lib.mkOption {
-            description = ''
-              The base DN for the embedded LDAP.
-
-              :::{note}
-              Setting this value to a non-empty string
-              will start the embedded LDAP,
-              no matter the value of {nix:option}`"embedded_ldap.enabled"`,
-              which may lead to port conflicts
-              if you deploy multiple Phoebus services.
-              :::
-            '';
-            type = lib.types.str;
-            default = if cfg.settings."embedded_ldap.enabled" == "true" then "dc=olog,dc=local" else "";
-            defaultText = lib.literalExpression ''if cfg.settings."embedded_ldap.enabled" == "true" then "dc=olog,dc=local" else ""'';
           };
         };
       };
@@ -112,12 +82,16 @@ in
     assertions = [
       {
         assertion =
-          with cfg;
-          (settings."ad.enabled" == "true")
-          || settings."ldap.enabled" == "true"
-          || settings."embedded_ldap.enabled" == "true"
-          || settings."demo_auth.enabled" == "true";
-        message = "One type of authentication for Phoebus Olog must be provided";
+          !(
+            cfg.settings ? "demo_auth.enabled"
+            || cfg.settings ? "ad.enabled"
+            || cfg.settings ? "ldap.enabled"
+            || cfg.settings ? "embedded_ldap.enabled"
+          );
+        message = ''
+          The Phoebus Olog settings `demo_auth.enabled`, `ad.enabled`, `ldap.enabled`, and `embedded_ldap.enabled` were removed.
+          Please use `authenticationProviders` instead, and set it to "inMemory", "activeDirectory", "ldap", or "embedded_ldap" instead.
+        '';
       }
     ];
 
@@ -131,7 +105,7 @@ in
       ];
 
       serviceConfig = {
-        ExecStart = "${lib.getExe pkgs.epnix.phoebus-olog} --spring.config.location=file://${configFile}";
+        ExecStart = "${lib.getExe pkgs.epnix.phoebus-olog} --spring.config.location=classpath:/application.properties,file://${configFile}";
         Type = "exec";
         Restart = "on-failure";
         DynamicUser = true;

--- a/nixos/modules/phoebus/olog.nix
+++ b/nixos/modules/phoebus/olog.nix
@@ -84,6 +84,19 @@ in
                 [upstream's authentication documentation]: https://olog.readthedocs.io/en/latest/sysadmin/guides/configuring/authentication.html
             '';
           };
+
+          "embedded_ldap_ldif" = lib.mkOption {
+            description = ''
+              Path to an [LDIF] file describing the content of the embedded LDAP server.
+
+              Only valid if {nix:option}`authenticationProviders` contains `"embeddedLdap"`.
+
+                [LDIF]: https://en.wikipedia.org/wiki/LDAP_Data_Interchange_Format
+            '';
+            type = lib.types.str;
+            default = "classpath:olog.ldif";
+            example = lib.literalExpression ''"file://''${./olog.ldif}"'';
+          };
         };
         config = {
           # Disable SSL

--- a/nixos/modules/phoebus/olog.nix
+++ b/nixos/modules/phoebus/olog.nix
@@ -24,6 +24,12 @@ in
 
         See here for supported options:
         <https://github.com/Olog/phoebus-olog/blob/v${pkgs.epnix.phoebus-olog.version}/src/main/resources/application.properties>
+
+        :::{note}
+        Contrary to upstream,
+        the Phoebus Olog service listens to HTTP connections,
+        not HTTPS.
+        :::
       '';
       default = { };
       type = lib.types.submodule {
@@ -36,14 +42,7 @@ in
             # It says it supports integers and booleans, but during the build
             # only accepts strings?
             apply = toString;
-            description = "The server port for the REST service.";
-          };
-
-          "server.http.enable" = lib.mkOption {
-            type = lib.types.bool;
-            default = false;
-            apply = lib.boolToString;
-            description = "Enable unsecure HTTP.";
+            description = "The HTTP server port for the REST service.";
           };
 
           "authenticationProviders" = lib.mkOption {
@@ -73,6 +72,18 @@ in
                 [upstream's authentication documentation]: https://olog.readthedocs.io/en/latest/sysadmin/guides/configuring/authentication.html
             '';
           };
+        };
+        config = {
+          # Disable SSL
+          "security.require-ssl" = lib.mkDefault false;
+          "server.ssl.enabled" = lib.mkDefault false;
+          # Unset the loading of private keys from the Git repository
+          "server.ssl.key-store-type" = lib.mkDefault "";
+          "server.ssl.key-store" = lib.mkDefault "";
+          "server.ssl.key-store-password" = lib.mkDefault "";
+          "server.ssl.key-alias" = lib.mkDefault "";
+          # We've already switched to HTTP, no need for a second one
+          "server.http.enable" = lib.mkDefault false;
         };
       };
     };

--- a/nixos/modules/phoebus/save-and-restore.nix
+++ b/nixos/modules/phoebus/save-and-restore.nix
@@ -215,7 +215,7 @@ in
       after = [ "elasticsearch.service" ];
 
       serviceConfig = {
-        ExecStart = "${lib.getExe pkgs.epnix.phoebus-save-and-restore} --spring.config.location=file://${configFile}";
+        ExecStart = "${lib.getExe pkgs.epnix.phoebus-save-and-restore} --spring.config.location=classpath:/application.properties,file://${configFile}";
         Type = "exec";
         Restart = "always";
 

--- a/nixos/tests/phoebus/olog.ldif
+++ b/nixos/tests/phoebus/olog.ldif
@@ -1,0 +1,28 @@
+dn: ou=Group,dc=olog,dc=local
+objectClass: organizationalunit
+ou: Group
+description: groups branch
+
+dn: ou=People,dc=olog,dc=local
+objectClass: organizationalunit
+ou: People
+description: people branch
+
+dn: uid=ext-user,ou=People,dc=olog,dc=local
+uid: ext-user
+objectClass: account
+objectClass: posixAccount
+description: User with tag role
+cn: ext-user
+# bcrypt encoded string "ext-user-pass"
+userPassword: $2b$05$BtWyHnII7L8o33PRqR9hquxb5A4X3SaOla3yZKOd.9AAE6ou/ju/i
+uidNumber: 23001
+gidNumber: 23001
+homeDirectory: /dev/null
+
+dn: cn=olog-logs,ou=Group,dc=olog,dc=local
+cn: olog-logs
+objectClass: posixGroup
+description: olog-logs group
+gidNumber: 24004
+memberUid: ext-user

--- a/nixos/tests/phoebus/olog.nix
+++ b/nixos/tests/phoebus/olog.nix
@@ -13,6 +13,7 @@
       {
         services.phoebus-olog = {
           enable = true;
+          openFirewall = true;
           settings = {
             "authenticationProviders" = [
               "inMemory"
@@ -35,8 +36,6 @@
             # any service, this should be fine.
             "elasticsearch"
           ];
-
-        networking.firewall.allowedTCPPorts = [ 8181 ];
 
         # Else phoebus-olog gets killed by the OOM killer
         virtualisation.memorySize = 2047;

--- a/nixos/tests/phoebus/olog.nix
+++ b/nixos/tests/phoebus/olog.nix
@@ -57,7 +57,7 @@
     client.wait_for_unit("multi-user.target")
 
     # TODO: properly configure certificates
-    status_str = client.succeed("curl -sSfL -k https://server:8181/Olog")
+    status_str = client.succeed("curl -sSfL -k http://server:8181/Olog")
     status = json.loads(status_str)
 
     with subtest("Olog connected to ElasticSearch"):
@@ -67,13 +67,13 @@
         assert "state=CONNECTED" in status["mongoDB"]
 
     def get(uri: str) -> Any:
-        result = client.succeed(f"curl -sSfL -k https://server:8181/Olog{uri}")
+        result = client.succeed(f"curl -sSfL -k http://server:8181/Olog{uri}")
         return json.loads(result)
 
     def put(uri: str, data: Any) -> Any:
         result = client.succeed(
             "curl -sSfL -k -X PUT -u admin:adminPass "
-            f"'https://server:8181/Olog{uri}' "
+            f"'http://server:8181/Olog{uri}' "
             "-H 'Content-Type: application/json' "
             f"-d {repr(json.dumps(data))}"
         )
@@ -86,22 +86,22 @@
     with subtest("can login using inMemory auth provider"):
         credentials = {"username": "admin", "password": "adminPass"}
         client.succeed(
-            "curl -sSfL -k -X POST 'https://server:8181/Olog/login' "
+            "curl -sSfL -k -X POST 'http://server:8181/Olog/login' "
             f"-H 'Content-Type: application/json' -d {repr(json.dumps(credentials))} "
             "--cookie-jar cjar"
         )
-        user_str = client.succeed("curl -sSfL -k 'https://server:8181/Olog/user' --cookie cjar")
+        user_str = client.succeed("curl -sSfL -k 'http://server:8181/Olog/user' --cookie cjar")
         user = json.loads(user_str)
         assert user["userName"] == "admin"
 
     with subtest("can login using embeddedLdap auth provider"):
         credentials = {"username": "ext-user", "password": "ext-user-pass"}
         client.succeed(
-            "curl -sSfL -k -X POST 'https://server:8181/Olog/login' "
+            "curl -sSfL -k -X POST 'http://server:8181/Olog/login' "
             f"-H 'Content-Type: application/json' -d {repr(json.dumps(credentials))} "
             "--cookie-jar cjar"
         )
-        user_str = client.succeed("curl -sSfL -k 'https://server:8181/Olog/user' --cookie cjar")
+        user_str = client.succeed("curl -sSfL -k 'http://server:8181/Olog/user' --cookie cjar")
         user = json.loads(user_str)
         assert user["userName"] == "ext-user"
 

--- a/nixos/tests/phoebus/olog.nix
+++ b/nixos/tests/phoebus/olog.nix
@@ -13,7 +13,11 @@
       {
         services.phoebus-olog = {
           enable = true;
-          settings."demo_auth.enabled" = true;
+          settings = {
+            "authenticationProviders" = [
+              "inMemory"
+            ];
+          };
         };
 
         services.elasticsearch = {

--- a/nixos/tests/phoebus/olog.nix
+++ b/nixos/tests/phoebus/olog.nix
@@ -16,7 +16,9 @@
           settings = {
             "authenticationProviders" = [
               "inMemory"
+              "embeddedLdap"
             ];
+            "embedded_ldap_ldif" = "file://${./olog.ldif}";
           };
         };
 
@@ -81,7 +83,7 @@
         logbooks = get("/logbooks")
         assert len(logbooks) > 0, "No default logbook found"
 
-    with subtest("can login"):
+    with subtest("can login using inMemory auth provider"):
         credentials = {"username": "admin", "password": "adminPass"}
         client.succeed(
             "curl -sSfL -k -X POST 'https://server:8181/Olog/login' "
@@ -91,6 +93,17 @@
         user_str = client.succeed("curl -sSfL -k 'https://server:8181/Olog/user' --cookie cjar")
         user = json.loads(user_str)
         assert user["userName"] == "admin"
+
+    with subtest("can login using embeddedLdap auth provider"):
+        credentials = {"username": "ext-user", "password": "ext-user-pass"}
+        client.succeed(
+            "curl -sSfL -k -X POST 'https://server:8181/Olog/login' "
+            f"-H 'Content-Type: application/json' -d {repr(json.dumps(credentials))} "
+            "--cookie-jar cjar"
+        )
+        user_str = client.succeed("curl -sSfL -k 'https://server:8181/Olog/user' --cookie cjar")
+        user = json.loads(user_str)
+        assert user["userName"] == "ext-user"
 
     log_id = -1
 

--- a/pkgs/by-name/phoebus-olog/package.nix
+++ b/pkgs/by-name/phoebus-olog/package.nix
@@ -2,24 +2,34 @@
   lib,
   epnixLib,
   fetchFromGitHub,
-  jdk21_headless,
+  jdk25_headless,
   maven,
   makeWrapper,
 }:
 maven.buildMavenPackage rec {
   pname = "phoebus-olog";
-  version = "5.1.2";
+  version = "6.0.3";
 
   src = fetchFromGitHub {
     owner = "Olog";
     repo = "phoebus-olog";
     tag = "v${version}";
-    hash = "sha256-5LcDBisr+uu43B3WwwzDNFNVfchuZb9shWDipgGIo2Q=";
+    hash = "sha256-k5bkHKe5g8EFq9L1KMPrBZL9i27CPdW0U4nWHT5YhQ8=";
   };
 
-  mvnJdk = jdk21_headless;
-  mvnHash = "sha256-6I+d6XEd6XYMZVaWyhk6YPBWAf3DnF8Xh2fDdxV7xk0=";
+  buildOffline = true;
+  mvnJdk = jdk25_headless;
+  mvnHash = "sha256-PsBGGoQRkKPdpUi6tF2/4Hh3D/R3zNd4IvCHJKTXRbg=";
   mvnParameters = "-Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Pdeployable-jar";
+
+  # Dynamic test dependencies
+  # which aren't picked up by go-offline-maven-plugin
+  manualMvnArtifacts = [
+    "org.springframework.boot:spring-boot-maven-plugin:4.0.0-RC1"
+    "org.apache.maven.surefire:surefire-junit-platform:3.5.4"
+    "org.junit.platform:junit-platform-launcher:1.12.2"
+    "org.jacoco:org.jacoco.agent:0.8.10:jar:runtime"
+  ];
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -33,7 +43,7 @@ maven.buildMavenPackage rec {
 
     install -Dm644 target/service-olog-${version}.jar $out/share/java
 
-    makeWrapper ${lib.getExe jdk21_headless} $out/bin/${meta.mainProgram} \
+    makeWrapper ${lib.getExe jdk25_headless} $out/bin/${meta.mainProgram} \
       --add-flags "-jar $out/share/java/$jarName"
 
     runHook postInstall
@@ -45,6 +55,6 @@ maven.buildMavenPackage rec {
     mainProgram = "phoebus-olog";
     license = lib.licenses.epl10;
     maintainers = with epnixLib.maintainers; [ minijackson ];
-    inherit (jdk21_headless.meta) platforms;
+    inherit (jdk25_headless.meta) platforms;
   };
 }


### PR DESCRIPTION
Changes:

- https://github.com/Olog/phoebus-olog/releases/tag/v6.0.0
- https://github.com/Olog/phoebus-olog/releases/tag/v6.0.1
- https://github.com/Olog/phoebus-olog/releases/tag/v6.0.3

See the release notes for the breaking changes.

The service now listens to HTTP instead of HTTPS, since the private key is publicly readable in the upstream Git repository.

And now we have a proper Phoebus Olog documentation!

cc @achoqt for review, since you might be interested by the changes and documentation.

Best reviewed commit by commit.

Fixes #525

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [x] The feature has automated tests
    - [x] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [x] The feature is documented
    - [x] The documentation is up to date
    - Release notes:
        - [x] Added an entry if the change is breaking or significant
        - [x] Added an entry when adding a new feature
