### PR TITLE
Phoebus alarm hardening

### DIFF
--- a/docs/nixos-services/user-guides/phoebus-alarm.md
+++ b/docs/nixos-services/user-guides/phoebus-alarm.md
@@ -1,4 +1,4 @@
-# Phoebus Alarm single server setup
+# Phoebus Alarm
 
 The Phoebus Alarm collection of services enables monitoring EPICS PVs,
 and report alarms in a server.

--- a/docs/nixos-services/user-guides/phoebus-alarm.md
+++ b/docs/nixos-services/user-guides/phoebus-alarm.md
@@ -226,7 +226,69 @@ Here is a list of options you might want to set:
 Currently, Phoebus Alarm Server only supports plain SMTP.
 :::
 
+## Custom alert channels
+
+Alert channels other than mails must be configured
+through running external commands.
+
+The Phoebus Alarm service is heavily hardened,
+for reasons explained in the {ref}`danger indication <phoebus-alarm-danger>`,
+meaning that the service will have restricted access to available commands
+and files from the host.
+
+To create host-accessible files and directories,
+use the `$STATE_DIRECTORY` environment variable,
+which corresponds to the {file}`/var/lib/phoebus-alarm-server` directory
+on the host.
+
+To make a command available to the Phoebus Alarm service,
+use the {nix:option}`services.phoebus-alarm-server.path` option.
+
+Nixpkgs provides a [`writeShellApplication`] function
+to create custom commands with dependencies.
+One example of a configuration that creates a `phoebus-alarm-send-alert` command,
+which uses {program}`curl`
+to send an alert through an HTTP API:
+
+```{code-block} nix
+:caption: {file}`phoebus-alarm.nix` --- {program}`curl` example
+
+{lib, pkgs, ...}: let
+  alertCommand = ;
+in {
+  services.phoebus-alarm-server = {
+    # ...
+    path = [
+      (pkgs.writeShellApplication {
+        # Name of the command
+        name = "phoebus-alarm-send-alert";
+        # Make your script depend on the 'curl' package
+        runtimeInputs = [ pkgs.curl ];
+        # Content of the script
+        text = ''
+          # If "*" is given as argument in the configuration,
+          # the first argument is the PV name
+          ALARM_PV="$1"
+          # and the second argument is the alarm severity
+          ALARM_SEVERITY="$2"
+
+          curl -sSfL "https://my-server.example.com/api/alarm/webhook" \
+            -X POST \
+            --header "Content-Type: application/json" \
+            -d '{"pv": "'$ALARM_PV'", "severity": "'$ALARM_SEVERITY'"}'
+        '';
+      })
+    ];
+  };
+}
+```
+
+To use this command,
+make sure your alarm node uses `cmd:phoebus-alarm-send-alert *` as command,
+including the `*` to pass the PV and severity as argument.
+
 [alarm logging service]: https://control-system-studio.readthedocs.io/en/latest/services/alarm-logger/doc/index.html
 [alarm server]: https://control-system-studio.readthedocs.io/en/latest/services/alarm-server/doc/index.html
 [service architecture]: https://control-system-studio.readthedocs.io/en/latest/services_architecture.html
 [the readme of alarm server]: https://github.com/ControlSystemStudio/phoebus/blob/master/app/alarm/Readme.md
+[`writeShellApplication`]: https://nixos.org/manual/nixpkgs/stable/#trivial-builder-writeShellApplication

--- a/docs/nixos-services/user-guides/phoebus-alarm.md
+++ b/docs/nixos-services/user-guides/phoebus-alarm.md
@@ -5,6 +5,30 @@ and report alarms in a server.
 Phoebus clients can then contact this server,
 to see a list of current alarms, earlier alarms, and so on.
 
+(phoebus-alarm-danger)=
+:::{danger}
+The current design of the Phoebus alarm server allows any user
+that has access to the Kafka server
+to specify arbitrary commands to run when alarms are triggered.
+This includes Phoebus graphical clients,
+which must have Kafka access to be able
+to configure alarms,
+read alarm states,
+and acknowledge alarms.
+
+This guide provides instructions
+on how to setup a Kafka server *without* authentication,
+meaning that anyone one the network may run arbitrary commands on your alarm server.
+
+The current EPNix implementation tries
+to hardened and isolate the Phoebus alarm service
+to mitigate the risk,
+but this still leaves a bit attack surface.
+
+Make sure the physical machine hosting the Phoebus alarm server doesn't host anything important,
+and try to isolate it as much as possible from a network perspective.
+:::
+
 This guide focuses on installing and configuring these services on a single server.
 
 For more information about these services,

--- a/docs/release-notes/2605.md
+++ b/docs/release-notes/2605.md
@@ -9,6 +9,9 @@
   because the Alarm Server might run arbitrary commands from the network,
   often without any authentication.
 
+  See the {ref}`Phoebus alarm danger indication <phoebus-alarm-danger>`
+  for a more in-depth explanation.
+
 ## New features and highlights
 
 - {pkg}`epnix.channel-finder-service` was upgraded to `5.0.0+`

--- a/docs/release-notes/2605.md
+++ b/docs/release-notes/2605.md
@@ -5,7 +5,9 @@
 
 ## Breaking changes
 
-No breaking change were introduced in this EPNix release.
+- The {option}`services.phoebus-alarm-server` and {option}`services.phoebus-alarm-logger` NixOS modules were heavily hardened,
+  because the Alarm Server might run arbitrary commands from the network,
+  often without any authentication.
 
 ## New features and highlights
 

--- a/docs/release-notes/2605.md
+++ b/docs/release-notes/2605.md
@@ -33,3 +33,6 @@
 
 - The {doc}`../ioc/user-guides/testing/python-scripts` article was rewritten
   and is now much simpler.
+
+- The {doc}`../nixos-services/user-guides/phoebus-alarm` guide now has a section
+  on how to add custom alarm scripts.

--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -168,6 +168,8 @@ in
           in
           "${lib.getExe pkgs.epnix.phoebus-alarm-logger} ${lib.concatStringsSep " " args}";
         DynamicUser = true;
+        Type = "exec";
+        Restart = "on-failure";
         StateDirectory = "phoebus-alarm-logger";
 
         # Sandboxing

--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -169,7 +169,37 @@ in
           "${lib.getExe pkgs.epnix.phoebus-alarm-logger} ${lib.concatStringsSep " " args}";
         DynamicUser = true;
         StateDirectory = "phoebus-alarm-logger";
-        # TODO: systemd hardening
+
+        # Sandboxing
+        LockPersonality = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = "strict";
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+
+        # Capabilities
+        CapabilityBoundingSet = "";
+
+        # System call filtering
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        SystemCallErrorNumber = "EPERM";
       };
     };
 

--- a/nixos/modules/phoebus/alarm-server.nix
+++ b/nixos/modules/phoebus/alarm-server.nix
@@ -9,7 +9,7 @@ let
   cfg = config.services.phoebus-alarm-server;
   settingsFormat = pkgs.formats.javaProperties { };
   configFile = settingsFormat.generate "phoebus-alarm-server.properties" cfg.settings;
-  configLocation = "phoebus/alarm-server.properties";
+  configLocation = "phoebus/alarm-server/application.properties";
 in
 {
   options.services.phoebus-alarm-server = {
@@ -201,8 +201,59 @@ in
       serviceConfig = {
         ExecStart = "${lib.getExe pkgs.epnix.phoebus-alarm-server} -noshell -settings /etc/${configLocation}";
         DynamicUser = true;
+
         StateDirectory = "phoebus-alarm-server";
-        # TODO: systemd hardening
+        ConfigurationDirectory = "phoebus/alarm-server::ro";
+
+        BindReadOnlyPaths = [
+          # /etc/phoebus/alarm-server/* are symbolic links to /etc/static/phoebus/alarm-server/*
+          # and we want them in the chroot
+          "/etc/static/phoebus/alarm-server"
+          # Phoebus needs the hostname
+          "${config.environment.etc."hosts".source}:/etc/hosts"
+          "${
+            config.environment.etc."ssl/certs/ca-certificates.crt".source
+          }:/etc/ssl/certs/ca-certificates.crt"
+        ];
+
+        # Not set because since we have a chroot,
+        # setting it to `true` would *add* `/dev`, `/proc`, etc., to the chroot.
+        # PrivateDevices = true;
+        # ProtectHome = true;
+        # ProtectHostname = true;
+        # ProtectKernelModules = true;
+        # ProtectKernelTunables = true;
+        # ProtectProc = "invisible";
+        # ProtectSystem = "strict";
+
+        # Sandboxing
+        LockPersonality = true;
+        ProtectClock = true;
+        ProtectKernelLogs = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+
+        # Capabilities
+        CapabilityBoundingSet = "";
+
+        # System call filtering
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        SystemCallErrorNumber = "EPERM";
+      };
+      confinement = {
+        enable = true;
+        mode = "chroot-only";
+        packages = [
+          configFile
+        ];
       };
     };
 

--- a/nixos/modules/phoebus/alarm-server.nix
+++ b/nixos/modules/phoebus/alarm-server.nix
@@ -255,6 +255,8 @@ in
       serviceConfig = {
         ExecStart = "${lib.getExe pkgs.epnix.phoebus-alarm-server} -noshell -settings /etc/${configLocation}";
         DynamicUser = true;
+        Type = "exec";
+        Restart = "on-failure";
 
         StateDirectory = "phoebus-alarm-server";
         ConfigurationDirectory = "phoebus/alarm-server::ro";

--- a/nixos/modules/phoebus/alarm-server.nix
+++ b/nixos/modules/phoebus/alarm-server.nix
@@ -37,6 +37,45 @@ in
       default = false;
     };
 
+    path = lib.mkOption {
+      description = ''
+        Extra packages to add
+        to the PATH of the `phoebus-alarm-server.service` systemd unit.
+
+        These packages may be used as commands configured in individual alarms.
+      '';
+      type =
+        with lib.types;
+        listOf (oneOf [
+          package
+          str
+        ]);
+      default = [ ];
+      example = lib.literalExpression ''
+        [
+          (pkgs.writeShellApplication {
+            # Name of the command
+            name = "phoebus-alarm-send-alert";
+            # Make your script depend on the 'curl' package
+            runtimeInputs = [ pkgs.curl ];
+            # Content of the script
+            text = '''
+              # If "*" is given as argument in the configuration,
+              # the first argument is the PV name
+              ALARM_PV="$1"
+              # and the second argument is the alarm severity
+              ALARM_SEVERITY="$2"
+
+              curl -sSfL "https://my-server.example.com/api/alarm/webhook" \
+                -X POST \
+                --header "Content-Type: application/json" \
+                -d '{"pv": "'$ALARM_PV'", "severity": "'$ALARM_SEVERITY'"}'
+            ''';
+          })
+        ]
+      '';
+    };
+
     settings = lib.mkOption {
       description = ''
         Configuration for the Phoebus Alarm Server.
@@ -203,6 +242,7 @@ in
 
     systemd.services.phoebus-alarm-server = {
       description = "Phoebus Alarm Server";
+      inherit (cfg) path;
 
       wantedBy = [ "multi-user.target" ];
       # If the user has installed a Kafka server,
@@ -265,9 +305,7 @@ in
       confinement = {
         enable = true;
         mode = "chroot-only";
-        packages = [
-          configFile
-        ];
+        packages = [ configFile ] ++ cfg.path;
       };
     };
 

--- a/nixos/modules/phoebus/alarm-server.nix
+++ b/nixos/modules/phoebus/alarm-server.nix
@@ -162,6 +162,19 @@ in
             type = lib.types.str;
             default = "";
           };
+
+          # Command options:
+          # ---
+
+          "org.phoebus.applications.alarm/command_directory" = lib.mkOption {
+            description = ''
+              Directory used for executing commands.
+
+              May use Java system properties like this: `$(prop_name)`.
+            '';
+            type = lib.types.str;
+            default = "/var/lib/phoebus-alarm-server";
+          };
         };
       };
     };

--- a/nixos/modules/phoebus/alarm-server.nix
+++ b/nixos/modules/phoebus/alarm-server.nix
@@ -197,6 +197,7 @@ in
       after = [ "apache-kafka.service" ];
 
       environment.JAVA_OPTS = "-Dphoebus.user=/var/lib/phoebus-alarm-server";
+      restartTriggers = [ config.environment.etc."${configLocation}".source ];
 
       serviceConfig = {
         ExecStart = "${lib.getExe pkgs.epnix.phoebus-alarm-server} -noshell -settings /etc/${configLocation}";

--- a/nixos/tests/phoebus/alarm.nix
+++ b/nixos/tests/phoebus/alarm.nix
@@ -49,6 +49,25 @@
           enable = true;
           openFirewall = true;
           settings."org.phoebus.applications.alarm/server" = kafkaListenSockAddr;
+          path = [
+            (pkgs.writeShellApplication {
+              name = "alarm-cmd";
+              text = ''
+                echo "Running alarm command"
+
+                text="all good"
+                if [[ "$1" != "arg1" ]]; then
+                  text="wrong argument"
+                fi
+                shift
+
+                ALARM_PV="$1"
+                ALARM_SEVERITY="$2"
+
+                echo "$text: $ALARM_PV $ALARM_SEVERITY" > "$STATE_DIRECTORY/alarm-cmd-result"
+              '';
+            })
+          ];
         };
 
         environment.epics = {

--- a/nixos/tests/phoebus/alarm.py
+++ b/nixos/tests/phoebus/alarm.py
@@ -75,7 +75,18 @@ with subtest("Topics are created"):
 with subtest("Can monitor a PV"):
     send_kafka(
         alarm_config,
-        {"user": "root", "host": "localhost.localdomain", "description": "The Alarm"},
+        {
+            "user": "root",
+            "host": "localhost.localdomain",
+            "description": "The Alarm",
+            "actions": [
+                {
+                    "title": "Run a custom command",
+                    "delay": 0,
+                    "details": "cmd:alarm-cmd arg1 *",
+                },
+            ],
+        },
     )
 
 with subtest("Alarm logger is aware of the config"):
@@ -101,6 +112,13 @@ with subtest("We can trigger an MINOR alarm"):
 
     assert alarm["current_severity"] == "MINOR"
     assert alarm["severity"] == "MINOR"
+
+with subtest("The alarm command was run"):
+    server.wait_for_file("/var/lib/phoebus-alarm-server/alarm-cmd-result")
+    result = server.succeed(
+        "cat /var/lib/phoebus-alarm-server/alarm-cmd-result"
+    ).strip()
+    assert result == "all good: ALARM_TEST MINOR"
 
 with subtest("We can trigger an MAJOR alarm"):
     client.succeed("caput ALARM_TEST 4")

--- a/nixos/tests/phoebus/alarm.py
+++ b/nixos/tests/phoebus/alarm.py
@@ -211,7 +211,7 @@ with subtest("The data is still here after a server reboot"):
 
 with subtest("Can export alarm configuration"):
     server.succeed(
-        "phoebus-alarm-server -settings /etc/phoebus/alarm-server.properties -export export.xml"
+        "phoebus-alarm-server -settings /etc/phoebus/alarm-server/application.properties -export export.xml"
     )
     server.succeed("grep ALARM_TEST export.xml")
     server.copy_from_vm("export.xml")


### PR DESCRIPTION
- Harden the Phoebus Alarm service, since it executes arbitrary commands from the network (via Kafka).

- Document the security risks of deploying the Phoebus Alarm server

- Document how to run custom commands on alarm

- Some misc alarm-related fixes, like restarting the services on failure (which should help the `phoebus-alarm` integration test)

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [x] The feature has automated tests
    - [x] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [x] The feature is documented
    - [x] The documentation is up to date
    - Release notes:
        - [x] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
