### PR TITLE
treewide: set Restart=always for Java services

### DIFF
--- a/nixos/modules/channel-finder/service.nix
+++ b/nixos/modules/channel-finder/service.nix
@@ -190,7 +190,7 @@ in
       serviceConfig = {
         ExecStart = "${lib.getExe pkgs.epnix.channel-finder-service} --spring.config.location=file://${configFile}";
         Type = "exec";
-        Restart = "on-failure";
+        Restart = "always";
 
         DynamicUser = true;
 

--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -170,7 +170,7 @@ in
         Type = "exec";
         DynamicUser = true;
         Type = "exec";
-        Restart = "on-failure";
+        Restart = "always";
         StateDirectory = "phoebus-alarm-logger";
 
         # Sandboxing

--- a/nixos/modules/phoebus/alarm-server.nix
+++ b/nixos/modules/phoebus/alarm-server.nix
@@ -257,7 +257,7 @@ in
         Type = "exec";
         DynamicUser = true;
         Type = "exec";
-        Restart = "on-failure";
+        Restart = "always";
 
         StateDirectory = "phoebus-alarm-server";
         ConfigurationDirectory = "phoebus/alarm-server::ro";

--- a/nixos/modules/phoebus/save-and-restore.nix
+++ b/nixos/modules/phoebus/save-and-restore.nix
@@ -217,7 +217,7 @@ in
       serviceConfig = {
         ExecStart = "${lib.getExe pkgs.epnix.phoebus-save-and-restore} --spring.config.location=file://${configFile}";
         Type = "exec";
-        Restart = "on-failure";
+        Restart = "always";
 
         DynamicUser = true;
 


### PR DESCRIPTION
Those services don't consistently return a non-zero exit code, meaning systemd believes the service exited successfully.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
