### PR TITLE
nixos/*: use coercedTo option types

### DIFF
--- a/nixos/modules/archiver-appliance.nix
+++ b/nixos/modules/archiver-appliance.nix
@@ -210,14 +210,13 @@ in
 
               Use `lib.mkForce` to override values from {nix:option}`environment.epics.ca_addr_list`.
             '';
-            type = with lib.types; listOf str;
+            # Separated by spaces -> toString
+            type = with lib.types; coercedTo (listOf str) toString str;
             defaultText = lib.literalExpression ''
               if config.environment.epics.enable
               then config.environment.epics.ca_addr_list
               else [];
             '';
-            # Separated by spaces
-            apply = toString;
           };
 
           EPICS_CA_AUTO_ADDR_LIST = lib.mkOption {
@@ -227,13 +226,12 @@ in
 
               Use `lib.mkForce` to override values from {nix:option}`environment.epics.ca_auto_addr_list`.
             '';
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToYesNo str;
             defaultText = lib.literalExpression ''
               if config.environment.epics.enable
               then config.environment.epics.ca_auto_addr_list
               else [];
             '';
-            apply = b: if b then "YES" else "NO";
           };
         };
       };

--- a/nixos/modules/channel-finder/recceiver.nix
+++ b/nixos/modules/channel-finder/recceiver.nix
@@ -79,22 +79,20 @@ in
             };
 
             addrlist = lib.mkOption {
-              type = with lib.types; listOf str;
+              type = with lib.types; coercedTo (listOf str) (lib.concatStringsSep ",") str;
               default = [ "255.255.255.255:5049" ];
-              apply = lib.concatStringsSep ",";
               description = ''
                 List of broadcast addresses.
               '';
             };
 
             procs = lib.mkOption {
-              type = with lib.types; listOf str;
+              type = with lib.types; coercedTo (listOf str) (lib.concatStringsSep ",") str;
               default = [ "show" ];
               example = [
                 "show"
                 "cf"
               ];
-              apply = lib.concatStringsSep ",";
               description = ''
                 Processing chain, sequence of plugin names.
 
@@ -118,14 +116,15 @@ in
 
           cf = {
             environment_vars = lib.mkOption {
-              type = with lib.types; attrsOf str;
+              type =
+                with lib.types;
+                coercedTo (attrsOf str) (lib.concatMapAttrsStringSep "," (k: v: "${k}:${v}")) str;
               default = { };
               example = {
                 ENGINEER = "Engineer";
                 EPICS_BASE = "EpicsVersion";
                 PWD = "WorkingDirectory";
               };
-              apply = val: lib.concatStringsSep "," (lib.mapAttrsToList (k: v: "${k}:${v}") val);
               description = ''
                 Attribute set of `VARIABLE = "PropertyName";`
 

--- a/nixos/modules/channel-finder/service.nix
+++ b/nixos/modules/channel-finder/service.nix
@@ -46,55 +46,46 @@ in
         freeformType = settingsFormat.type;
         options = {
           "server.port" = lib.mkOption {
-            type = lib.types.port;
+            type = with lib.types; coercedTo port toString str;
             default = 8443;
-            # TODO: Weirdness of the javaProperties format?
-            # It says it supports integers and booleans, but during the build
-            # only accepts strings?
-            apply = toString;
             description = "The HTTPS server port for the ChannelFinder service";
           };
 
           "server.http.enable" = lib.mkOption {
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToString str;
             default = true;
-            apply = lib.boolToString;
             description = "Enable unsecure HTTP";
           };
 
           "server.http.port" = lib.mkOption {
-            type = lib.types.port;
+            type = with lib.types; coercedTo port toString str;
             default = 8080;
-            apply = toString;
             description = "The HTTP server port for the ChannelFinder service";
           };
 
           "elasticsearch.host_urls" = lib.mkOption {
-            type = with lib.types; listOf str;
+            type = with lib.types; coercedTo (listOf str) (lib.concatStringsSep ",") str;
             default = [ "http://localhost:9200" ];
             description = ''
               List of URLs for the Elasticsearch hosts.
 
               All hosts listed here must belong to the same Elasticsearch cluster.
             '';
-            apply = lib.concatStringsSep ",";
           };
 
           "elasticsearch.create.indices" = lib.mkOption {
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToString str;
             default = true;
             description = ''
               List of URLs for the Elasticsearch hosts.
 
               All hosts listed here must belong to the same Elasticsearch cluster.
             '';
-            apply = lib.boolToString;
           };
 
           "demo_auth.enabled" = lib.mkOption {
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToString str;
             default = false;
-            apply = lib.boolToString;
             description = ''
               Enable the demo authentication.
 
@@ -106,18 +97,16 @@ in
           };
 
           "ldap.enabled" = lib.mkOption {
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToString str;
             default = false;
-            apply = lib.boolToString;
             description = ''
               Enable authenticating to an external LDAP server.
             '';
           };
 
           "embedded_ldap.enabled" = lib.mkOption {
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToString str;
             default = false;
-            apply = lib.boolToString;
             description = ''
               Enable the embedded LDAP authentication.
             '';

--- a/nixos/modules/phoebus/alarm-logger.nix
+++ b/nixos/modules/phoebus/alarm-logger.nix
@@ -47,16 +47,14 @@ in
         options = {
           "server.port" = lib.mkOption {
             description = "Port for the Alarm Logger service";
-            type = lib.types.port;
+            type = with lib.types; coercedTo port toString str;
             default = 8080;
-            apply = toString;
           };
 
           alarm_topics = lib.mkOption {
             description = "Alarm topics to be logged";
-            type = with lib.types; listOf str;
+            type = with lib.types; coercedTo (listOf str) (lib.concatStringsSep ",") str;
             default = [ "Accelerator" ];
-            apply = lib.concatStringsSep ",";
           };
 
           es_urls = lib.mkOption {
@@ -65,24 +63,21 @@ in
 
               All nodes must belong to the same cluster.
             '';
-            type = with lib.types; listOf str;
+            type = with lib.types; coercedTo (listOf str) (lib.concatStringsSep ",") str;
             default = [ "http://localhost:${toString config.services.elasticsearch.port}" ];
             defaultText = lib.literalExpression ''[ "http://localhost:''${toString config.services.elasticsearch.port}" ]'';
-            apply = lib.concatStringsSep ",";
           };
 
           es_sniff = lib.mkOption {
             description = "Use the Elasticseach sniff feature";
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToString str;
             default = false;
-            apply = lib.boolToString;
           };
 
           es_create_templates = lib.mkOption {
             description = "Automatically create the index templates needed";
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToString str;
             default = true;
-            apply = lib.boolToString;
           };
 
           "bootstrap.servers" = lib.mkOption {
@@ -111,9 +106,8 @@ in
 
               Two threads per topic/configuration are required.
             '';
-            type = lib.types.ints.positive;
+            type = with lib.types; coercedTo ints.positive toString str;
             default = 4;
-            apply = toString;
           };
         };
       };

--- a/nixos/modules/phoebus/alarm-server.nix
+++ b/nixos/modules/phoebus/alarm-server.nix
@@ -94,13 +94,13 @@ in
 
               Use `lib.mkForce` to override values from {nix:option}`environment.epics.ca_addr_list`.
             '';
-            type = with lib.types; listOf str;
+            # Separated by spaces -> toString
+            type = with lib.types; coercedTo (listOf str) toString str;
             defaultText = lib.literalExpression ''
               if config.environment.epics.enable
               then config.environment.epics.ca_addr_list
               else [];
             '';
-            apply = lib.concatStringsSep " ";
           };
 
           "org.phoebus.pv.ca/auto_addr_list" = lib.mkOption {
@@ -109,13 +109,12 @@ in
 
               Use `lib.mkForce` to override values from {nix:option}`environment.epics.ca_auto_addr_list`.
             '';
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToString str;
             defaultText = lib.literalExpression ''
               if config.environment.epics.enable
               then config.environment.epics.ca_auto_addr_list
               else [];
             '';
-            apply = lib.boolToString;
           };
 
           "org.phoebus.applications.alarm/server" = lib.mkOption {
@@ -142,11 +141,10 @@ in
 
               Will be used as the name for the Kafka topic.
             '';
-            type = with lib.types; listOf str;
+            type = with lib.types; coercedTo (listOf str) (lib.concatStringsSep ",") str;
             # TODO: bug? From the code it seems that specifying multiple topics
             # here with create_topics will have issues (AlarmServerMain.java:654)
             default = [ "Accelerator" ];
-            apply = lib.concatStringsSep ",";
           };
 
           # Email options:
@@ -166,9 +164,8 @@ in
             description = ''
               The SMTP server port.
             '';
-            type = lib.types.port;
+            type = with lib.types; coercedTo port toString str;
             default = 25;
-            apply = toString;
           };
 
           "org.phoebus.email/username" = lib.mkOption {

--- a/nixos/modules/phoebus/client.nix
+++ b/nixos/modules/phoebus/client.nix
@@ -176,13 +176,13 @@ in
 
               Use `lib.mkForce` to override values from {nix:option}`environment.epics.ca_addr_list`.
             '';
-            type = with lib.types; listOf str;
+            # Separated by spaces -> toString
+            type = with lib.types; coercedTo (listOf str) toString str;
             defaultText = lib.literalExpression ''
               if config.environment.epics.enable
               then config.environment.epics.ca_addr_list
               else [];
             '';
-            apply = lib.concatStringsSep " ";
           };
 
           "org.phoebus.pv.ca/auto_addr_list" = lib.mkOption {
@@ -191,13 +191,12 @@ in
 
               Use `lib.mkForce` to override values from {nix:option}`environment.epics.ca_auto_addr_list`.
             '';
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToString str;
             defaultText = lib.literalExpression ''
               if config.environment.epics.enable
               then config.environment.epics.ca_auto_addr_list
               else [];
             '';
-            apply = lib.boolToString;
           };
 
           "org.csstudio.display.builder.model/color_files" = lib.mkOption {
@@ -271,8 +270,7 @@ in
                 -   May then contain characters or numbers
                 -   May also contain underscores
             '';
-            type = with lib.types; attrsOf str;
-            apply = toMacrosXML;
+            type = with lib.types; coercedTo (attrsOf str) toMacrosXML str;
             default = { };
             example = {
               EXAMPLE_MACRO = "Value from Preferences";

--- a/nixos/modules/phoebus/olog.nix
+++ b/nixos/modules/phoebus/olog.nix
@@ -48,12 +48,8 @@ in
         freeformType = settingsFormat.type;
         options = {
           "server.port" = lib.mkOption {
-            type = lib.types.port;
+            type = with lib.types; coercedTo port toString str;
             default = 8181;
-            # TODO: Weirdness of the javaProperties format?
-            # It says it supports integers and booleans, but during the build
-            # only accepts strings?
-            apply = toString;
             description = "The HTTP server port for the REST service.";
           };
 

--- a/nixos/modules/phoebus/save-and-restore.nix
+++ b/nixos/modules/phoebus/save-and-restore.nix
@@ -49,9 +49,8 @@ in
         options = {
           "server.port" = lib.mkOption {
             description = "Port for the Save-and-restore service";
-            type = lib.types.port;
+            type = with lib.types; coercedTo port toString str;
             default = 8080;
-            apply = toString;
           };
 
           "auth.impl" = lib.mkOption {
@@ -197,10 +196,9 @@ in
 
           "elasticsearch.http.port" = lib.mkOption {
             description = "Elasticsearch server port.";
-            type = lib.types.port;
+            type = with lib.types; coercedTo port toString str;
             default = config.services.elasticsearch.port;
             defaultText = lib.literalExpression "config.services.elasticsearch.port";
-            apply = toString;
           };
         };
       };

--- a/nixos/modules/pvws.nix
+++ b/nixos/modules/pvws.nix
@@ -99,14 +99,13 @@ in
 
               Use `lib.mkForce` to override values from {nix:option}`environment.epics.ca_addr_list`.
             '';
-            type = with lib.types; listOf str;
+            # Separated by spaces -> toString
+            type = with lib.types; coercedTo (listOf str) toString str;
             defaultText = lib.literalExpression ''
               if config.environment.epics.enable
               then config.environment.epics.ca_addr_list
               else [];
             '';
-            # Separated by spaces
-            apply = toString;
           };
 
           EPICS_CA_AUTO_ADDR_LIST = lib.mkOption {
@@ -116,13 +115,12 @@ in
 
               Use `lib.mkForce` to override values from {nix:option}`environment.epics.ca_auto_addr_list`.
             '';
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToYesNo str;
             defaultText = lib.literalExpression ''
               if config.environment.epics.enable
               then config.environment.epics.ca_auto_addr_list
               else [];
             '';
-            apply = b: if b then "YES" else "NO";
           };
 
           PV_DEFAULT_TYPE = lib.mkOption {
@@ -134,10 +132,9 @@ in
 
           PV_WRITE_SUPPORT = lib.mkOption {
             description = "Whether to enable PV write support.";
-            type = lib.types.bool;
+            type = with lib.types; coercedTo bool lib.boolToString str;
             default = false;
             example = true;
-            apply = lib.boolToString;
           };
         };
       };


### PR DESCRIPTION
This allows users to specify the option as raw, instead of using the semantic Nix type.


<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
