### PR TITLE
flake: upgrade NixOS 25.11 -> 26.05

### DIFF
--- a/docs/contributing/guides/release-process.md
+++ b/docs/contributing/guides/release-process.md
@@ -45,7 +45,7 @@ so a major Nixpkgs upgrade might cause those hashes to change.
 Build the packages that have Maven hashes in them:
 
 ```bash
-nix build -L \
+nix build -L --keep-going \
   '.#channel-finder-service' \
   '.#phoebus-olog' \
   '.#phoebus-deps'
@@ -112,11 +112,11 @@ Create a commit for each resolved TODO.
 ### Run the tests
 
 Run the EPNix checks.
-This can be done by pushing your branch to DRF's GitLab
+This can be done by opening a PR on GitHub with your changes
 and waiting for the CI to complete.
 
-If you don't have access to DRF's GitLab,
-run `nix flake check -L`.
+You can also run the tests locally
+by running `nix flake check -L`.
 
 :::{caution}
 Running all EPNix checks can take a lot of resources.

--- a/docs/ioc/tutorials/integration-tests.md
+++ b/docs/ioc/tutorials/integration-tests.md
@@ -394,7 +394,7 @@ machine.wait_for_open_port(9999)
 ```
 :::
 
-:::{py:function} retry(fn: Callable, timeout: int = 900)
+:::{py:function} retry(fn: Callable, timeout_seconds: int = 900)
 Call the given function repeatedly, with 1-second intervals,
 until it returns `True` or a timeout is reached.
 
@@ -406,7 +406,7 @@ def check_value(_last_call: bool) -> bool:
     value = float(machine.succeed("caget -t VOLT-RB"))
     return value == 42.
 
-retry(check_value, timeout=10)
+retry(check_value, 10)
 ```
 :::
 
@@ -462,7 +462,7 @@ with subtest("check voltage"):
         value = float(machine.succeed("caget -t VOLT-RB"))
         return value == 42.
 
-    retry(check_value, timeout=10)
+    retry(check_value, 10)
 ```
 
 Note that the script uses the `wait_until_succeeds` method and the `retry` function.

--- a/flake.lock
+++ b/flake.lock
@@ -55,16 +55,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782847189,
-        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "lastModified": 1784432872,
+        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A Nix flake containing EPICS-related modules and packages";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-utils.url = "github:numtide/flake-utils";
     sphinxcontrib-nixdomain = {
       url = "github:minijackson/sphinxcontrib-nixdomain";

--- a/flake.nix
+++ b/flake.nix
@@ -118,9 +118,9 @@
       templates.default = self.templates.top;
       templates.top = {
         path = ./templates/top;
-        description = "An EPNix TOP project (next-generation)";
+        description = "An EPNix TOP project";
         welcomeText = ''
-          You have created a next-generation EPNix top.
+          You have created an EPNix top.
 
           Don't forget to run `makeBaseApp.pl` and `epicsConfigurePhase` inside the development shell before compiling it.
 

--- a/formatter.nix
+++ b/formatter.nix
@@ -1,7 +1,7 @@
 {
   treefmt,
   clang-tools,
-  nixfmt-rfc-style,
+  nixfmt,
   ruff,
   shfmt,
   taplo,
@@ -65,7 +65,7 @@ treefmt.withConfig {
   };
   runtimeInputs = [
     clang-tools
-    nixfmt-rfc-style
+    nixfmt
     ruff
     shfmt
     taplo

--- a/ioc/tests/support/StreamDevice/simple/default.nix
+++ b/ioc/tests/support/StreamDevice/simple/default.nix
@@ -43,7 +43,7 @@ in
         status, _output = machine.execute(f"caget -t '{pv}' | grep -qxF '{value}'")
         return status == 0
 
-      retry(do_caput, timeout=10)
+      retry(do_caput, 10)
 
     with subtest("getting initial values"):
       assert_caget("UCmd", "0")

--- a/nixos/modules/ca-gateway.nix
+++ b/nixos/modules/ca-gateway.nix
@@ -9,16 +9,17 @@ let
   cfg = config.services.ca-gateway;
   pkg = pkgs.epnix.ca-gateway;
 
-  # the CA gateway doesn't use the long/short options conventions
-  mkOptionName = k: "-${k}";
-  # List are for IP address lists
-  mkList = k: v: [
-    (mkOptionName k)
-    (lib.concatStringsSep " " v)
-  ];
-  toCommandLine = lib.cli.toGNUCommandLine { inherit mkOptionName mkList; };
+  optionFormat = optionName: {
+    # the CA gateway doesn't use the long/short options conventions
+    option = "-${optionName}";
+    sep = null;
+    explicitBool = false;
+  };
 
-  commandLine = lib.escapeShellArgs (toCommandLine cfg.settings);
+  # List are for IP address lists, separated by spaces -> toString
+  processLists = lib.mapAttrs (_: v: if lib.isList v then toString v else v);
+
+  commandLine = lib.escapeShellArgs (lib.cli.toCommandLine optionFormat (processLists cfg.settings));
 
   firewallOpt = options.services.ca-gateway.openFirewall;
 in

--- a/nixos/modules/iocs.nix
+++ b/nixos/modules/iocs.nix
@@ -200,7 +200,7 @@ let
                 procServ = lib.getExe pkgs.epnix.procServ;
               in
               ''
-                ${procServ} ${lib.cli.toGNUCommandLineShell { } config.procServ.options} \
+                ${procServ} ${lib.cli.toCommandLineShellGNU { } config.procServ.options} \
                   ${toString config.procServ.port} \
                   ${config.startupScript}
               '';

--- a/nixos/tests/channel-finder/test_script.py
+++ b/nixos/tests/channel-finder/test_script.py
@@ -61,7 +61,7 @@ with subtest("RecCeiver sent all properties"):
         property_names = {prop["name"] for prop in properties}
         return all_properties.issubset(property_names)
 
-    retry(has_all_properties, timeout=30)
+    retry(has_all_properties, 30)
 
 with subtest("RecCeiver sent all channels"):
 
@@ -107,7 +107,7 @@ with subtest("RecCeiver sent all channels"):
 
         return True
 
-    retry(has_all_channels, timeout=30)
+    retry(has_all_channels, 30)
 
 with subtest("Client considers itself synchronized"):
     client.succeed("caget -t Msg-I | grep -qxF Synchronized")

--- a/pkgs/by-name/channel-finder-service/fix-maven-plugin-versions.patch
+++ b/pkgs/by-name/channel-finder-service/fix-maven-plugin-versions.patch
@@ -1,0 +1,20 @@
+diff --git i/pom.xml w/pom.xml
+index 2040366..85b1179 100644
+--- i/pom.xml
++++ w/pom.xml
+@@ -268,6 +268,7 @@
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-dependency-plugin</artifactId>
++                <version>3.7.0</version>
+                 <executions>
+                     <execution>
+                         <id>copy</id>
+@@ -448,6 +449,7 @@
+                     <plugin>
+                         <groupId>org.apache.maven.plugins</groupId>
+                         <artifactId>maven-source-plugin</artifactId>
++                        <version>3.4.0</version>
+                         <executions>
+                             <execution>
+                                 <id>attach-sources</id>

--- a/pkgs/by-name/channel-finder-service/package.nix
+++ b/pkgs/by-name/channel-finder-service/package.nix
@@ -17,11 +17,14 @@ maven.buildMavenPackage rec {
     hash = "sha256-ID9XfHAomdVAKodUAOuMngWy/dDlFYhnDjpbDt7Uzig=";
   };
 
-  patches = [ ./support-github-archive.patch ];
+  patches = [
+    ./support-github-archive.patch
+    ./fix-maven-plugin-versions.patch
+  ];
 
   buildOffline = true;
   mvnJdk = jdk25_headless;
-  mvnHash = "sha256-tUo1mTGpLa1DTj3V9HkxalrVyjDgf49dg1TryPIv7Z0=";
+  mvnHash = "sha256-gE2Xql1gKEBMzjYndwK3A4FI3Fv4uV6xrN35O6P0BeY=";
   mvnParameters = "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z";
 
   # Dynamic test dependencies

--- a/pkgs/by-name/phoebus-olog/package.nix
+++ b/pkgs/by-name/phoebus-olog/package.nix
@@ -19,7 +19,7 @@ maven.buildMavenPackage rec {
 
   buildOffline = true;
   mvnJdk = jdk25_headless;
-  mvnHash = "sha256-PsBGGoQRkKPdpUi6tF2/4Hh3D/R3zNd4IvCHJKTXRbg=";
+  mvnHash = "sha256-ntZjIKU7fB/l+hd4fFAFKtlvAyGY2jffIg18+VNOFsY=";
   mvnParameters = "-Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Pdeployable-jar";
 
   # Dynamic test dependencies

--- a/pkgs/epics-base/default.nix
+++ b/pkgs/epics-base/default.nix
@@ -5,18 +5,19 @@
   epnixLib,
   buildPackages,
   fetchFromGitHub,
+  fetchpatch2,
   version,
   hash,
 }:
 let
-  older = lib.versionOlder version;
-
   generateConf = (epnixLib.formats.make { }).generate;
 
   # "build" as in Nix terminology (the build machine)
   build_arch = epnixLib.toEpicsArch stdenv.buildPlatform;
   # "host" as in Nix terminology (the machine which will run the generated code)
   host_arch = epnixLib.toEpicsArch stdenv.hostPlatform;
+
+  is3 = (lib.versions.major version) == "3";
 in
 mkEpicsPackage {
   pname = "epics-base";
@@ -33,10 +34,16 @@ mkEpicsPackage {
     fetchSubmodules = true;
   };
 
-  patches = lib.optionals (older "7.0.5") [
+  patches = lib.optionals is3 [
     # Support "undefine MYVAR" in convertRelease.pl
     # Fixed by commit 79d7ac931502e1c25b247a43b7c4454353ac13a6
     ./handle-make-undefine-variable.patch
+
+    (fetchpatch2 {
+      name = "fix-compile-error-in-tssllist.patch";
+      url = "https://github.com/epics-base/epics-base/commit/a509aa660d9f3ca3d2123fe16b89234065997fe6.patch?full_index=1";
+      hash = "sha256-g+PGW5cGIA4X5i0KNjX7ykZVKJ5/FI5dBNar5EatNDk=";
+    })
   ];
 
   # Configuration file for how to compile for the build machine.
@@ -89,6 +96,10 @@ mkEpicsPackage {
         CMPLR_CLASS = "clang";
       }
     );
+
+  local_config_site = lib.optionalAttrs is3 {
+    USR_CFLAGS = "-std=c11";
+  };
 
   postConfigure = ''
     echo "$build_config_site" > configure/os/CONFIG_SITE.${build_arch}.${build_arch}

--- a/pkgs/python-modules/by-name/epicscorelibs/package.nix
+++ b/pkgs/python-modules/by-name/epicscorelibs/package.nix
@@ -9,14 +9,17 @@
 }:
 buildPythonPackage rec {
   pname = "epicscorelibs";
-  version = "7.0.7.99.1.2";
+  version = "7.0.10.99.0.1";
 
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-KnSlO0OLu77vE8dGQKTTBg013njOiYnzFYFI84U0zUM=";
+    hash = "sha256-6MjZcw+u999V9NMpw1mg5MBE8DpSTdLkWH6QEyhz7f0=";
   };
+
+  # https://github.com/epics-base/epicscorelibs/pull/55
+  patches = [ ./use-typed-things.patch ];
 
   dontConfigure = true;
 

--- a/pkgs/python-modules/by-name/epicscorelibs/use-typed-things.patch
+++ b/pkgs/python-modules/by-name/epicscorelibs/use-typed-things.patch
@@ -1,0 +1,13 @@
+diff --git i/setup.py w/setup.py
+index 74840be0e..f4e251a51 100755
+--- i/setup.py
++++ w/setup.py
+@@ -443,7 +443,7 @@ def readlists(name, prefix):
+ modules = []
+ headers = ['epicsVersion.h']
+ 
+-local_defs = [('USE_TYPED_RSET', None)]
++local_defs = [('USE_TYPED_RSET', None), ('USE_TYPED_DSET', None), ('USE_TYPED_DRVET', None)]
+ 
+ def build_module(name, srcdir, defs=[], deps=[], srcs=[], soversion=None):
+     #print("Include EPICS module %s in %s"%(name, srcdir))

--- a/pkgs/support/by-name/StreamDevice/package.nix
+++ b/pkgs/support/by-name/StreamDevice/package.nix
@@ -3,6 +3,7 @@
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
+  fetchpatch2,
   asyn,
   calc,
   pcre,
@@ -23,6 +24,14 @@ mkEpicsPackage (finalAttrs: {
     forceFetchGit = true;
     hash = "sha256-/OgjdHvFr6sBRhOLa9F3KJeaxMiKuUuBduHUc4YLYBI=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "gcc-15-compatibility.patch";
+      url = "https://github.com/paulscherrerinstitute/StreamDevice/commit/929204cb13f122e2ff3beb64ab86d8bdb6a21d70.patch?full_index=1";
+      hash = "sha256-X9b/EicpzMXGMhSvgMrUjTvB7QW1lXJvc/zzlZPdYho=";
+    })
+  ];
 
   nativeBuildInputs = [ pcre ];
   buildInputs = [

--- a/pkgs/support/by-name/asyn/package.nix
+++ b/pkgs/support/by-name/asyn/package.nix
@@ -2,6 +2,7 @@
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
+  fetchpatch2,
   pkg-config,
   rpcsvc-proto,
   libtirpc,
@@ -20,7 +21,19 @@ mkEpicsPackage (finalAttrs: {
     hash = "sha256-VOHgDuRSj3dUmCWX+nyCf/i+VNGpC0ZsyIP0qBUG0vw=";
   };
 
-  patches = [ ./use-pkg-config.patch ];
+  patches = [
+    ./use-pkg-config.patch
+    (fetchpatch2 {
+      name = "fix-number-of-devsupfun-entries.patch";
+      url = "https://github.com/epics-modules/asyn/commit/b0340d83a903095f3a89163f90b2a48690d5021d.patch?full_index=1";
+      hash = "sha256-jRBj+7mWkhV8ma2p+FvwTvM+zmdSUuJ7sTgfGGiBJhI=";
+    })
+    (fetchpatch2 {
+      name = "explicitly-cast-function-pointers.patch";
+      url = "https://github.com/epics-modules/asyn/commit/8f3c8f651d12651908c845370431943ec4ef6d5c.patch?full_index=1";
+      hash = "sha256-34tyVhvvmmMhZ9UP9K/aexWla5Ni4bB7ozDINQUrKv8=";
+    })
+  ];
 
   local_config_site = {
     TIRPC = "YES";

--- a/pkgs/support/by-name/busy/package.nix
+++ b/pkgs/support/by-name/busy/package.nix
@@ -2,6 +2,7 @@
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
+  fetchpatch2,
   asyn,
   autosave,
   calc,
@@ -18,7 +19,14 @@ mkEpicsPackage (finalAttrs: {
     hash = "sha256-mSzFLj42iXkyWGWaxplfLehoQcULLpf745trYMd1XT4=";
   };
 
-  patches = [ ./fix-release.patch ];
+  patches = [
+    ./fix-release.patch
+    (fetchpatch2 {
+      name = "used-typed_dset-and-rset.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/epics-modules/busy/pull/17.patch?full_index=1";
+      hash = "sha256-EbZ6TixBN1Z+Yqu7LpatolPzONPbRDvrGxLabMakpqE=";
+    })
+  ];
 
   buildInputs = [
     calc

--- a/pkgs/support/by-name/calc/package.nix
+++ b/pkgs/support/by-name/calc/package.nix
@@ -2,6 +2,7 @@
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
+  fetchpatch2,
   sscan,
 }:
 mkEpicsPackage (finalAttrs: {
@@ -15,6 +16,14 @@ mkEpicsPackage (finalAttrs: {
     tag = "R${finalAttrs.version}";
     sha256 = "sha256-S40HtO7HXDS27u7wmlxuo7oV1abtj1EaXfIz0Kj1IM0=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "fix-build-errors-with-std-c23.patch";
+      url = "https://github.com/epics-modules/calc/commit/2da37a62f2b64e904294c2257874f0a8defa19ca.patch?full_index=1";
+      hash = "sha256-ZoWXGqa7GrTYs+nWIU8wyXAxo/X0QwR5o6pxB3+XGTM=";
+    })
+  ];
 
   propagatedBuildInputs = [ sscan ];
 

--- a/pkgs/support/by-name/gtest/package.nix
+++ b/pkgs/support/by-name/gtest/package.nix
@@ -2,6 +2,7 @@
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
+  fetchpatch2,
 }:
 mkEpicsPackage (finalAttrs: {
   pname = "gtest";
@@ -14,6 +15,14 @@ mkEpicsPackage (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-cDZ4++AkUiOvsw4KkobyqKWLk2GzUSdDdWjLL7dr1ac=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "fix-compile-error-with-newer-gcc.patch";
+      url = "https://github.com/epics-modules/gtest/commit/fb7e1f4053081e9f523ae671a801ce4c5565dc66.patch?full_index=1";
+      hash = "sha256-2QO5Oif1TODC1XOpxN4tfza2n8chq9sBlu4jHFs2RD0=";
+    })
+  ];
 
   meta = {
     description = "EPICS module to adds the Google Test and Google Mock frameworks to EPICS";

--- a/pkgs/support/by-name/mrfioc2/fix-c23-build.patch
+++ b/pkgs/support/by-name/mrfioc2/fix-c23-build.patch
@@ -1,0 +1,31 @@
+diff --git i/evrApp/src/devWfMailbox.c w/evrApp/src/devWfMailbox.c
+index 2ce264ec..ce05267b 100644
+--- i/evrApp/src/devWfMailbox.c
++++ w/evrApp/src/devWfMailbox.c
+@@ -88,8 +88,8 @@ struct {
+     5,
+     NULL,
+     NULL,
+-    init_record,
++    (DEVSUPFUN)init_record,
+     NULL,
+-    read_wf
++    (DEVSUPFUN)read_wf
+ };
+ epicsExportAddress(dset, devWfMailbox);
+diff --git i/mrfCommon/src/devMbboDirectSoft.c w/mrfCommon/src/devMbboDirectSoft.c
+index af569a06..ef2255d4 100644
+--- i/mrfCommon/src/devMbboDirectSoft.c
++++ w/mrfCommon/src/devMbboDirectSoft.c
+@@ -43,9 +43,9 @@ struct {
+ 	5,
+ 	NULL,
+ 	NULL,
+-	init_record,
++	(DEVSUPFUN)init_record,
+ 	NULL,
+-	write_mbbo
++	(DEVSUPFUN)write_mbbo
+ };
+ epicsExportAddress(dset,devMbboDirectRestore);
+ 

--- a/pkgs/support/by-name/mrfioc2/package.nix
+++ b/pkgs/support/by-name/mrfioc2/package.nix
@@ -16,6 +16,11 @@ mkEpicsPackage (finalAttrs: {
     hash = "sha256-AWwpv5JbnFwLMp/wku0lgI7TL0O0hqC+ycP/ypzwGbU=";
   };
 
+  patches = [
+    # https://github.com/epics-modules/mrfioc2/pull/226
+    ./fix-c23-build.patch
+  ];
+
   propagatedBuildInputs = [ devlib2 ];
 
   meta = {

--- a/pkgs/support/by-name/opcua/package.nix
+++ b/pkgs/support/by-name/opcua/package.nix
@@ -2,6 +2,7 @@
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
+  fetchpatch2,
   pkg-config,
   open62541_1_3,
   openssl,
@@ -30,7 +31,14 @@ mkEpicsPackage (finalAttrs: {
     OPEN62541_USE_XMLPARSER = "YES";
   };
 
-  patches = [ ./dir_xml2.patch ];
+  patches = [
+    ./dir_xml2.patch
+    (fetchpatch2 {
+      name = "fix-gcc-15-problem.patch";
+      url = "https://github.com/epics-modules/opcua/commit/485922c1e9b5bcce34d87be7bc5a6545209f8986.patch?full_index=1";
+      hash = "sha256-UnqAGbMCSZ3anvPiWE0LFRBx2Z0cTeI8W+rXfCxV4sI=";
+    })
+  ];
 
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [

--- a/pkgs/support/by-name/seq/package.nix
+++ b/pkgs/support/by-name/seq/package.nix
@@ -10,7 +10,11 @@ mkEpicsPackage {
   version = "2.2.9";
   varname = "SNCSEQ";
 
-  nativeBuildInputs = [ re2c ];
+  src = fetchdarcs {
+    url = "https://hub.darcs.net/bf/seq-branch-2-2";
+    rev = "R2-2-9";
+    sha256 = "sha256-LAqR5Mrph6CNrhpyt/uP5qbaWN0y7sJk6mfxnCk2Jx0=";
+  };
 
   patches = [
     ./remove-date.patch
@@ -24,15 +28,11 @@ mkEpicsPackage {
     })
   ];
 
+  nativeBuildInputs = [ re2c ];
+
   preBuild = ''
     echo 'include $(TOP)/configure/RELEASE.local' >> configure/RELEASE
   '';
-
-  src = fetchdarcs {
-    url = "https://hub.darcs.net/bf/seq-branch-2-2";
-    rev = "R2-2-9";
-    sha256 = "sha256-LAqR5Mrph6CNrhpyt/uP5qbaWN0y7sJk6mfxnCk2Jx0=";
-  };
 
   # TODO: Some tests fail
   doCheck = false;

--- a/pkgs/support/by-name/seq/package.nix
+++ b/pkgs/support/by-name/seq/package.nix
@@ -1,19 +1,21 @@
 {
+  lib,
   epnixLib,
   mkEpicsPackage,
-  fetchdarcs,
+  fetchFromGitHub,
   fetchpatch2,
   re2c,
 }:
-mkEpicsPackage {
+mkEpicsPackage (finalAttrs: {
   pname = "seq";
   version = "2.2.9";
   varname = "SNCSEQ";
 
-  src = fetchdarcs {
-    url = "https://hub.darcs.net/bf/seq-branch-2-2";
-    rev = "R2-2-9";
-    sha256 = "sha256-LAqR5Mrph6CNrhpyt/uP5qbaWN0y7sJk6mfxnCk2Jx0=";
+  src = fetchFromGitHub {
+    owner = "epics-modules";
+    repo = "sequencer";
+    tag = "R${lib.replaceString "." "-" finalAttrs.version}";
+    sha256 = "sha256-FVwj6puPEGYW23X0JlpgHpAKszdVuHp9bQ7B8lNhGu4=";
   };
 
   patches = [
@@ -43,4 +45,4 @@ mkEpicsPackage {
     license = epnixLib.licenses.epics;
     maintainers = with epnixLib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/support/by-name/seq/package.nix
+++ b/pkgs/support/by-name/seq/package.nix
@@ -2,6 +2,7 @@
   epnixLib,
   mkEpicsPackage,
   fetchdarcs,
+  fetchpatch2,
   re2c,
 }:
 mkEpicsPackage {
@@ -15,6 +16,12 @@ mkEpicsPackage {
     ./remove-date.patch
     # See: https://epics.anl.gov/epics/tech-talk/2022/msg01183.php
     ./remove_rules_compat.patch
+
+    (fetchpatch2 {
+      name = "lemon-add-missing-arguments-to-prototypes.patch";
+      url = "https://github.com/epics-modules/sequencer/commit/de4f7c21fb73a4fe780fa25c78d725ac050409de.patch?full_index=1";
+      hash = "sha256-Sqso2NMVLw4GkCDCpp2AA9O444NueGt/bXkLXslcx5k=";
+    })
   ];
 
   preBuild = ''

--- a/pkgs/support/by-name/sscan/fix-k-r-xdrproc-def.patch
+++ b/pkgs/support/by-name/sscan/fix-k-r-xdrproc-def.patch
@@ -1,0 +1,13 @@
+diff --git i/sscanApp/src/writeXDR.h w/sscanApp/src/writeXDR.h
+index 9ac3a1f..e9e338b 100644
+--- i/sscanApp/src/writeXDR.h
++++ w/sscanApp/src/writeXDR.h
+@@ -2,7 +2,7 @@
+ #include <stdio.h>
+ #include <epicsTypes.h>
+ 
+-typedef int (*xdrproc_t)();
++typedef int (*xdrproc_t)(FILE*, char*);
+ 
+ extern int write_XDR_Init();
+ extern int writeXDR_char(FILE *fd, char *cp);

--- a/pkgs/support/by-name/sscan/package.nix
+++ b/pkgs/support/by-name/sscan/package.nix
@@ -6,15 +6,20 @@
 }:
 mkEpicsPackage (finalAttrs: {
   pname = "sscan";
-  version = "2-11-6";
+  version = "2-12";
   varname = "SSCAN";
 
   src = fetchFromGitHub {
     owner = "epics-modules";
-    repo = finalAttrs.pname;
+    repo = "sscan";
     tag = "R${finalAttrs.version}";
-    sha256 = "sha256-hrPap4FBKMD4ddMrADOeTAmsG+rLFxALibT3qsAHNsk=";
+    sha256 = "sha256-3ayoRUPBv8lNnM80VNRCMN6FHbq4csogbrFkwoPjHrI=";
   };
+
+  patches = [
+    # https://github.com/epics-modules/sscan/pull/41
+    ./fix-k-r-xdrproc-def.patch
+  ];
 
   buildInputs = [ seq ];
 


### PR DESCRIPTION
This PR just upgrades the `master` branch to use NixOS 26.05. This isn't a new EPNix release yet.

Also contains small fixes in the release process guide.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
