### PR TITLE
treewide: don't use backticks in makefiles

### DIFF
--- a/docs/contributing/tutorials/packaging-asyn.md
+++ b/docs/contributing/tutorials/packaging-asyn.md
@@ -723,7 +723,7 @@ with a call to `pkg-config --cflags`:
 # Replace these kinds of lines:
 USR_INCLUDES_Linux += -I/usr/include/tirpc
 # With:
-USR_INCLUDES_Linux += `pkg-config --cflags libtirpc`
+USR_INCLUDES_Linux += $(shell pkg-config --cflags libtirpc)
 ```
 
 ### Creating the patch

--- a/docs/contributing/tutorials/packaging-asyn/my-asyn/use-pkg-config.patch
+++ b/docs/contributing/tutorials/packaging-asyn/my-asyn/use-pkg-config.patch
@@ -7,7 +7,7 @@ index 3f803f48..20974179 100644
  USR_CPPFLAGS += -DUSE_TYPED_RSET -DUSE_TYPED_DSET -DUSE_TYPED_DRVET
  
 -USR_INCLUDES_cygwin32 += -I/usr/include/tirpc
-+USR_INCLUDES_cygwin32 += `pkg-config --cflags libtirpc`
++USR_INCLUDES_cygwin32 += $(shell pkg-config --cflags libtirpc)
  
  # The following gets rid of the -fno-implicit-templates flag on vxWorks, 
  # so we get automatic template instantiation.
@@ -16,7 +16,7 @@ index 3f803f48..20974179 100644
  # Define TIRPC in configure/CONFIG_SITE in this case
  ifeq ($(TIRPC),YES)
 -  USR_INCLUDES_Linux += -I/usr/include/tirpc
-+  USR_INCLUDES_Linux += `pkg-config --cflags libtirpc`
++  USR_INCLUDES_Linux += $(shell pkg-config --cflags libtirpc)
    asyn_SYS_LIBS_Linux += tirpc
  endif
  
@@ -29,7 +29,7 @@ index 20957003..e619dc28 100644
  testGpib_LIBS += testSupport asyn
  ifeq ($(TIRPC),YES)
 -  USR_INCLUDES += -I/usr/include/tirpc
-+  USR_INCLUDES += `pkg-config --cflags libtirpc`
++  USR_INCLUDES += $(shell pkg-config --cflags libtirpc)
    testGpib_SYS_LIBS += tirpc
  endif
  SYS_PROD_LIBS_cygwin32 += $(CYGWIN_RPC_LIB)

--- a/pkgs/support/by-name/asyn/use-pkg-config.patch
+++ b/pkgs/support/by-name/asyn/use-pkg-config.patch
@@ -7,7 +7,7 @@ index 7ce295c8..4774be2b 100644
  # Define TIRPC in configure/CONFIG_SITE in this case
  ifeq ($(TIRPC),YES)
 -  USR_INCLUDES_Linux += -I/usr/include/tirpc
-+  USR_INCLUDES += `pkg-config --cflags libtirpc`
++  USR_INCLUDES += $(shell pkg-config --cflags libtirpc)
    asyn_SYS_LIBS_Linux += tirpc
  endif
  
@@ -20,7 +20,7 @@ index 20957003..e619dc28 100644
  testGpib_LIBS += testSupport asyn
  ifeq ($(TIRPC),YES)
 -  USR_INCLUDES += -I/usr/include/tirpc
-+  USR_INCLUDES += `pkg-config --cflags libtirpc`
++  USR_INCLUDES += $(shell pkg-config --cflags libtirpc)
    testGpib_SYS_LIBS += tirpc
  endif
  SYS_PROD_LIBS_cygwin32 += $(CYGWIN_RPC_LIB)

--- a/pkgs/support/by-name/opcua/dir_xml2.patch
+++ b/pkgs/support/by-name/opcua/dir_xml2.patch
@@ -7,7 +7,7 @@ index d1b82cb..5d81dc2 100644
  USR_INCLUDES += -I$(MSYSTEM_PREFIX)/include/libxml2
  else
 -USR_INCLUDES += -I/usr/include/libxml2
-+USR_INCLUDES += `pkg-config --cflags libxml-2.0`
++USR_INCLUDES += $(shell pkg-config --cflags libxml-2.0)
  endif
  
  opcua_SRCS += Session.cpp
@@ -20,10 +20,10 @@ index c52a727..8c2556b 100644
  ifeq ($($(CLIENT)_USE_XMLPARSER),YES)
  USR_CXXFLAGS += -DHAS_XMLPARSER
 -USR_INCLUDES_Linux += -I/usr/include/libxml2
-+USR_INCLUDES += `pkg-config --cflags libxml-2.0`
++USR_INCLUDES += $(shell pkg-config --cflags libxml-2.0)
  ifneq ($(filter -D_MINGW,$(OP_SYS_CPPFLAGS)),)
 -USR_INCLUDES += -I$(MSYSTEM_PREFIX)/include/libxml2
-+USR_INCLUDES += `pkg-config --cflags libxml-2.0`
++USR_INCLUDES += $(shell pkg-config --cflags libxml-2.0)
  USR_SYS_LIBS += xml2
  endif
  endif


### PR DESCRIPTION
This changes patches so that we dont use `` ` `` backticks inside makefile because make doesn't interpret it, so the command gets executed each time the variable is used in a command-line, instead of once.


<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
