### PR TITLE
support.asyn: 4-45 -> 4-46

### DIFF
--- a/pkgs/support/by-name/StreamDevice/package.nix
+++ b/pkgs/support/by-name/StreamDevice/package.nix
@@ -31,6 +31,11 @@ mkEpicsPackage (finalAttrs: {
       url = "https://github.com/paulscherrerinstitute/StreamDevice/commit/929204cb13f122e2ff3beb64ab86d8bdb6a21d70.patch?full_index=1";
       hash = "sha256-X9b/EicpzMXGMhSvgMrUjTvB7QW1lXJvc/zzlZPdYho=";
     })
+    (fetchpatch2 {
+      name = "in-recent-asyn-versions-vxi11-is-optional.patch";
+      url = "https://github.com/paulscherrerinstitute/StreamDevice/commit/e87e093c846ca19383462036d2f85ca5369b17b3.patch?full_index=1";
+      hash = "sha256-kwxIfKfAQtdmV5Y6uYsS+P4OFWf4q4Uez0qvK/7NApA=";
+    })
   ];
 
   nativeBuildInputs = [ pcre ];

--- a/pkgs/support/by-name/asyn/package.nix
+++ b/pkgs/support/by-name/asyn/package.nix
@@ -2,7 +2,6 @@
   epnixLib,
   mkEpicsPackage,
   fetchFromGitHub,
-  fetchpatch2,
   pkg-config,
   rpcsvc-proto,
   libtirpc,
@@ -11,28 +10,18 @@
 }:
 mkEpicsPackage (finalAttrs: {
   pname = "asyn";
-  version = "4-45";
+  version = "4-46";
   varname = "ASYN";
 
   src = fetchFromGitHub {
     owner = "epics-modules";
     repo = "asyn";
     tag = "R${finalAttrs.version}";
-    hash = "sha256-VOHgDuRSj3dUmCWX+nyCf/i+VNGpC0ZsyIP0qBUG0vw=";
+    hash = "sha256-YdaVKfYo4JljXBrxHN39OFKCaZZtbOgHoLWWgrPhkZE=";
   };
 
   patches = [
     ./use-pkg-config.patch
-    (fetchpatch2 {
-      name = "fix-number-of-devsupfun-entries.patch";
-      url = "https://github.com/epics-modules/asyn/commit/b0340d83a903095f3a89163f90b2a48690d5021d.patch?full_index=1";
-      hash = "sha256-jRBj+7mWkhV8ma2p+FvwTvM+zmdSUuJ7sTgfGGiBJhI=";
-    })
-    (fetchpatch2 {
-      name = "explicitly-cast-function-pointers.patch";
-      url = "https://github.com/epics-modules/asyn/commit/8f3c8f651d12651908c845370431943ec4ef6d5c.patch?full_index=1";
-      hash = "sha256-34tyVhvvmmMhZ9UP9K/aexWla5Ni4bB7ozDINQUrKv8=";
-    })
   ];
 
   local_config_site = {

--- a/pkgs/support/by-name/asyn/use-pkg-config.patch
+++ b/pkgs/support/by-name/asyn/use-pkg-config.patch
@@ -1,25 +1,25 @@
-diff --git a/asyn/Makefile b/asyn/Makefile
-index 7ce295c8..4774be2b 100644
---- a/asyn/Makefile
-+++ b/asyn/Makefile
+diff --git i/asyn/Makefile w/asyn/Makefile
+index 1f2c21c7..e0aecbbb 100644
+--- i/asyn/Makefile
++++ w/asyn/Makefile
 @@ -33,7 +33,7 @@ asyn_SYS_LIBS_cygwin32 = $(CYGWIN_RPC_LIB)
  # Some linux systems moved RPC related symbols to libtirpc
  # Define TIRPC in configure/CONFIG_SITE in this case
  ifeq ($(TIRPC),YES)
--  USR_INCLUDES_Linux += -I/usr/include/tirpc
+-  USR_INCLUDES_Linux += -I$(SYSROOT)/usr/include/tirpc
 +  USR_INCLUDES += $(shell pkg-config --cflags libtirpc)
    asyn_SYS_LIBS_Linux += tirpc
  endif
  
-diff --git a/testGpibApp/src/Makefile b/testGpibApp/src/Makefile
-index 20957003..e619dc28 100644
---- a/testGpibApp/src/Makefile
-+++ b/testGpibApp/src/Makefile
+diff --git i/testGpibApp/src/Makefile w/testGpibApp/src/Makefile
+index fe806643..4b7abc0b 100644
+--- i/testGpibApp/src/Makefile
++++ w/testGpibApp/src/Makefile
 @@ -43,7 +43,7 @@ testGpibVx_SRCS_vxWorks += testGpibVx_registerRecordDeviceDriver.cpp
  testGpib_LIBS += devTestGpib
  testGpib_LIBS += testSupport asyn
  ifeq ($(TIRPC),YES)
--  USR_INCLUDES += -I/usr/include/tirpc
+-  USR_INCLUDES += -I$(SYSROOT)/usr/include/tirpc
 +  USR_INCLUDES += $(shell pkg-config --cflags libtirpc)
    testGpib_SYS_LIBS += tirpc
  endif


### PR DESCRIPTION
Contains a fix for StreamDevice
which assumed VXI11 support was always there.


<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [x] The feature has automated tests
    - [x] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
