### PR TITLE
Handle marked insecure Elasticsearch 7

### DIFF
--- a/docs/_vale/config/vocabularies/EPNix/accept.txt
+++ b/docs/_vale/config/vocabularies/EPNix/accept.txt
@@ -17,6 +17,7 @@ nginx
 Nix
 NixOS
 NixOps
+Nixpkgs
 Olog
 OpenLDAP
 procServ

--- a/docs/nixos-services/user-guides/channel-finder.md
+++ b/docs/nixos-services/user-guides/channel-finder.md
@@ -20,14 +20,14 @@ Make sure to follow the NixOS {doc}`prerequisites`.
 
 To enable the ChannelFinder service,
 use {nix:option}`services.channel-finder.enable` and related options.
-You will also need to enable ElasticSearch.
+You will also need to enable Elasticsearch.
 
 For example:
 
 ```{code-block} nix
 :caption: {file}`channel-finder.nix` --- ChannelFinder configuration example
 
-{lib, pkgs, ...}: {
+{ pkgs, ... }: {
   services.channel-finder = {
     enable = true;
     openFirewall = true;
@@ -50,12 +50,12 @@ For example:
     package = pkgs.elasticsearch7;
   };
 
-  # Elasticsearch, needed by ChannelFinder, is not free software (SSPL | Elastic License).
-  # To accept the license, add the code below:
-  nixpkgs.config.allowUnfreePredicate = pkg:
-    builtins.elem (lib.getName pkg) [
-      "elasticsearch"
-    ];
+  # Elasticsearch can be used as an SSPL-licensed software, which is
+  # not open-source. But as we're using it run tests, not exposing
+  # any service, this should be fine.
+  nixpkgs.config.allowUnfreePackages = [ "elasticsearch" ];
+  # While waiting for Nixpkgs' packaging of Elasticsearch 8 / 9.
+  nixpkgs.config.permittedInsecurePackages = [ pkgs.elasticsearch7.name ];
 }
 ```
 
@@ -65,6 +65,12 @@ You can open your browser at <http://localhost:8082/> to see the ChannelFinder a
 For more settings,
 examine the [ChannelFinder configuration] reference
 and the {nix:option}`services.channel-finder.settings` option.
+
+:::{caution}
+Elasticsearch 7 is end-of-life and considered insecure,
+but currently the only available Elasticsearch package in Nixpkgs.
+Make sure to deploy it on a trusted network.
+:::
 
 ### Authentication
 
@@ -173,7 +179,7 @@ For example:
 :caption: {file}`channel-finder.nix` --- RecCeiver configuration example
 :name: recceiver-configuration-example
 
-{lib, pkgs, ...}: {
+{ pkgs, ... }: {
   # Other previous options...
 
   services.recceiver = {
@@ -193,7 +199,10 @@ For example:
         # When receiving metadata,
         # print it on the command-line (show),
         # and send it to ChannelFinder (cf).
-        procs = ["show" "cf"];
+        procs = [
+          "show"
+          "cf"
+        ];
       };
       cf = {
         # PV metadata to send to ChannelFinder
@@ -204,7 +213,7 @@ For example:
     };
   };
 
-  networking.firewall.allowedTCPPorts = [5050];
+  networking.firewall.allowedTCPPorts = [ 5050 ];
 }
 ```
 
@@ -249,7 +258,7 @@ See {ref}`recceiver-firewall`.
 ```{code-block} nix
 :caption: {file}`channel-finder.nix` --- changing the RecCeiver address list
 
-{lib, pkgs, ...}: {
+{ pkgs, ... }: {
   # ...
 
   services.recceiver = {
@@ -260,7 +269,7 @@ See {ref}`recceiver-firewall`.
 
         # If you change the port,
         # make sure to also change it in the IOC firewall rules
-        addrlist = ["192.168.1.255:5049"];
+        addrlist = [ "192.168.1.255:5049" ];
       };
       # ...
     };
@@ -280,7 +289,7 @@ for example:
 ```{code-block} nix
 :caption: {file}`channel-finder.nix` --- adding custom metadata to ChannelFinder
 
-{lib, pkgs, ...}: {
+{ pkgs, ... }: {
   # ...
 
   services.recceiver = {
@@ -300,7 +309,7 @@ for example:
       };
     };
   };
-};
+}
 ```
 
 ### External ChannelFinder server

--- a/docs/nixos-services/user-guides/phoebus-alarm.md
+++ b/docs/nixos-services/user-guides/phoebus-alarm.md
@@ -47,7 +47,7 @@ Make sure to follow the NixOS {doc}`prerequisites`.
 
 ## Single server Phoebus Alarm setup
 
-To configure Phoebus Alarm, Phoebus Alarm Logger, Apache Kafka, and ElasticSearch on a single server,
+To configure Phoebus Alarm, Phoebus Alarm Logger, Apache Kafka, and Elasticsearch on a single server,
 add this to your configuration,
 while taking care of replacing the IP address
 and Kafka's `clusterId`:
@@ -55,7 +55,7 @@ and Kafka's `clusterId`:
 ```{code-block} nix
 :caption: {file}`phoebus-alarm.nix`
 
-{ lib, pkgs, ... }:
+{ pkgs, ... }:
 let
   # Replace this with your machine's external IP address
   # or DNS domain name
@@ -121,7 +121,7 @@ in
   # Open kafka to the outside world
   networking.firewall.allowedTCPPorts = [ 9092 ];
 
-  # Phoebus alarm needs ElasticSearch.
+  # Phoebus alarm needs Elasticsearch.
   # If not already enabled elsewhere in your configuration,
   # Enable it with the code below:
   services.elasticsearch = {
@@ -129,13 +129,12 @@ in
     package = pkgs.elasticsearch7;
   };
 
-  # Elasticsearch, needed by Phoebus Alarm Logger, is not free software (SSPL | Elastic License).
-  # To accept the license, add the code below:
-  nixpkgs.config.allowUnfreePredicate =
-    pkg:
-    builtins.elem (lib.getName pkg) [
-      "elasticsearch"
-    ];
+  # Elasticsearch can be used as an SSPL-licensed software, which is
+  # not open-source. But as we're using it run tests, not exposing
+  # any service, this should be fine.
+  nixpkgs.config.allowUnfreePackages = [ "elasticsearch" ];
+  # While waiting for Nixpkgs' packaging of Elasticsearch 8 / 9.
+  nixpkgs.config.permittedInsecurePackages = [ pkgs.elasticsearch7.name ];
 }
 ```
 
@@ -157,6 +156,12 @@ org.phoebus.applications.alarm.logging.ui/service_uri=http://192.168.1.42:8080
 :::{seealso}
 For more information about configuring the firewall for EPICS,
 see the {doc}`epics-firewall` guide.
+:::
+
+:::{caution}
+Elasticsearch 7 is end-of-life and considered insecure,
+but currently the only available Elasticsearch package in Nixpkgs.
+Make sure to deploy it on a trusted network.
 :::
 
 ## Configuring topics
@@ -182,9 +187,11 @@ add this configuration to the server:
 ```{code-block} nix
 :caption: {file}`phoebus-alarm.nix`
 
-{config, lib, ...}: let
-  topics = ["Project"];
-in {
+{ pkgs, ... }:
+let
+  topics = [ "Project" ];
+in
+{
   services.phoebus-alarm-server = {
     # ...
     settings = {
@@ -223,6 +230,7 @@ Here is a list of options you might want to set:
 ```{code-block} nix
 :caption: {file}`phoebus-alarm.nix`
 
+{ pkgs, ... }:
 {
   services.phoebus-alarm-server = {
     # ...
@@ -277,8 +285,7 @@ to send an alert through an HTTP API:
 ```{code-block} nix
 :caption: {file}`phoebus-alarm.nix` --- {program}`curl` example
 
-{ lib, pkgs, ... }:
-
+{ pkgs, ... }:
 {
   services.phoebus-alarm-server = {
     # ...

--- a/docs/nixos-services/user-guides/phoebus-olog.md
+++ b/docs/nixos-services/user-guides/phoebus-olog.md
@@ -32,6 +32,7 @@ add this to your configuration.
 ```{code-block} nix
 :caption: {file}`phoebus-olog.nix`
 
+{ pkgs, ... }:
 {
   services.phoebus-olog = {
     enable = true;
@@ -43,7 +44,7 @@ add this to your configuration.
     settings.authenticationProviders = [ "XXX" ];
   };
 
-  # Phoebus Olog needs ElasticSearch.
+  # Phoebus Olog needs Elasticsearch.
   # If not already enabled elsewhere in your configuration,
   # Enable it with the code below:
   services.elasticsearch = {
@@ -51,18 +52,24 @@ add this to your configuration.
     package = pkgs.elasticsearch7;
   };
 
-  # Elasticsearch, needed by Phoebus Olog, is not free software (SSPL | Elastic License).
-  # To accept the license, add the code below:
-  nixpkgs.config.allowUnfreePredicate = pkg:
-    builtins.elem (lib.getName pkg) [
-      "elasticsearch"
-    ];
+  # Elasticsearch can be used as an SSPL-licensed software, which is
+  # not open-source. But as we're using it run tests, not exposing
+  # any service, this should be fine.
+  nixpkgs.config.allowUnfreePackages = [ "elasticsearch" ];
+  # While waiting for Nixpkgs' packaging of Elasticsearch 8 / 9.
+  nixpkgs.config.permittedInsecurePackages = [ pkgs.elasticsearch7.name ];
 }
 ```
 
 :::{seealso}
 For a complete list of options related to Phoebus Olog,
 see {nix:option}`services.phoebus-olog`.
+:::
+
+:::{caution}
+Elasticsearch 7 is end-of-life and considered insecure,
+but currently the only available Elasticsearch package in Nixpkgs.
+Make sure to deploy it on a trusted network.
 :::
 
 ## Custom port
@@ -73,6 +80,7 @@ set the {nix:option}`services.phoebus-olog.settings."server.port"` option:
 ```{code-block} nix
 :caption: {file}`phoebus-olog.nix` --- Set custom HTTP port
 
+{ pkgs, ... }:
 {
   services.phoebus-olog = {
     enable = true;
@@ -127,6 +135,7 @@ To use it, set {nix:option}`services.phoebus-olog.settings.authenticationProvide
 ```{code-block} nix
 :caption: {file}`phoebus-olog.nix` --- Default values for in memory authentication
 
+{ pkgs, ... }:
 {
   services.phoebus-olog = {
     enable = true;
@@ -211,6 +220,7 @@ Here is an example configuration:
 ```{code-block} nix
 :caption: {file}`phoebus-olog.nix` --- Configure the external LDAP authentication
 
+{ pkgs, ... }:
 {
   services.phoebus-olog = {
     enable = true;

--- a/docs/nixos-services/user-guides/phoebus-save-and-restore.md
+++ b/docs/nixos-services/user-guides/phoebus-save-and-restore.md
@@ -21,7 +21,8 @@ add this to your configuration:
 ```{code-block} nix
 :caption: {file}`phoebus-save-and-restore.nix`
 
-{lib, ...}: {
+{ pkgs, ... }:
+{
   services.phoebus-save-and-restore = {
     enable = true;
     openFirewall = true;
@@ -31,7 +32,7 @@ add this to your configuration:
     settings."auth.impl" = "XXX";
   };
 
-  # Phoebus save-and-restore needs ElasticSearch.
+  # Phoebus save-and-restore needs Elasticsearch.
   # If not already enabled elsewhere in your configuration,
   # Enable it with the code below:
   services.elasticsearch = {
@@ -39,12 +40,12 @@ add this to your configuration:
     package = pkgs.elasticsearch7;
   };
 
-  # Elasticsearch, needed by Phoebus Save-and-restore, is not free software (SSPL | Elastic License).
-  # To accept the license, add the code below:
-  nixpkgs.config.allowUnfreePredicate = pkg:
-    builtins.elem (lib.getName pkg) [
-      "elasticsearch"
-    ];
+  # Elasticsearch can be used as an SSPL-licensed software, which is
+  # not open-source. But as we're using it run tests, not exposing
+  # any service, this should be fine.
+  nixpkgs.config.allowUnfreePackages = [ "elasticsearch" ];
+  # While waiting for Nixpkgs' packaging of Elasticsearch 8 / 9.
+  nixpkgs.config.permittedInsecurePackages = [ pkgs.elasticsearch7.name ];
 }
 ```
 
@@ -63,6 +64,12 @@ add this configuration
 org.phoebus.applications.saveandrestore.client/jmasar.service.url=http://192.168.1.42:8080/save-restore
 ```
 
+:::{caution}
+Elasticsearch 7 is end-of-life and considered insecure,
+but currently the only available Elasticsearch package in Nixpkgs.
+Make sure to deploy it on a trusted network.
+:::
+
 ## Custom port
 
 To use a custom HTTP port,
@@ -73,6 +80,7 @@ For example:
 ```{code-block} nix
 :caption: {file}`phoebus-save-and-restore.nix` --- Set custom HTTP port
 
+{ pkgs, ... }:
 {
   services.phoebus-save-and-restore = {
     enable = true;
@@ -126,6 +134,7 @@ and their default values:
 ```{code-block} nix
 :caption: {file}`phoebus-save-and-restore.nix` --- Default values for demo authentication
 
+{ pkgs, ... }:
 {
   services.phoebus-save-and-restore = {
     enable = true;
@@ -181,6 +190,7 @@ Configure Phoebus save-and-restore to use your LDIF file:
 ```{code-block} nix
 :caption: {file}`phoebus-save-and-restore.nix` --- Configure the embedded LDAP authentication
 
+{ pkgs, ... }:
 {
   services.phoebus-save-and-restore = {
     enable = true;
@@ -321,6 +331,7 @@ Here is an example configuration:
 ```{code-block} nix
 :caption: {file}`phoebus-save-and-restore.nix` --- Configure the external LDAP authentication
 
+{ pkgs, ... }:
 {
   services.phoebus-save-and-restore = {
     enable = true;

--- a/docs/release-notes/2405.md
+++ b/docs/release-notes/2405.md
@@ -10,7 +10,7 @@
 - The {option}`services.phoebus-alarm-server.enable`,
   {option}`services.phoebus-olog.enable`,
   and {option}`services.phoebus-save-and-restore.enable` options
-  don't enable ElasticSearch automatically anymore.
+  don't enable Elasticsearch automatically anymore.
   See {doc}`../nixos-services/user-guides/phoebus-alarm`
   and {doc}`../nixos-services/user-guides/phoebus-save-and-restore`
   for how to enable it yourself on the same server.

--- a/docs/release-notes/2605.md
+++ b/docs/release-notes/2605.md
@@ -68,6 +68,21 @@
   Either split your configuration into 2 machines,
   or use [declarative NixOS containers](https://nixos.org/manual/nixos/stable/#sec-declarative-containers).
 
+- Due to Elasticsearch 7 being end-of-life
+  and having vulnerabilities,
+  Nixpkgs 26.05 declared Elasticsearch 7 as insecure.
+  While waiting for the Elasticsearch 8 / 9 packages in Nixpkgs,
+  make sure you're not exposing Elasticsearch on an untrusted network
+  and add this configuration:
+
+  ```nix
+    # While waiting for Nixpkgs' packaging of Elasticsearch 8 / 9.
+    nixpkgs.config.permittedInsecurePackages = [ pkgs.elasticsearch7.name ];
+  ```
+
+  The documentation guides for affected services
+  where updated.
+
 ## New features and highlights
 
 - New packages for building a "Phoebus ecosystem VM"

--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784432872,
-        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
+        "lastModified": 1787640266,
+        "narHash": "sha256-MrkfE5hF5xx4L/0h5NyJ3xQkKVftwSuKSkFSrvlTxGY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
+        "rev": "f4f698677b11021a8f84f452e23ae9ef2427bec3",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782905613,
-        "narHash": "sha256-SvXJcAemihifkTn4BGvyE5K1FJX9bl4U8DQ5pqKvD0s=",
+        "lastModified": 1786031528,
+        "narHash": "sha256-cROiHKO3UbIKqF5FG5NikvydzlfIj4EcR1Cty9qOVt4=",
         "owner": "nix-community",
         "repo": "pyproject.nix",
-        "rev": "7af23cfe91064865ecf2e835da28b45b3c6f49fd",
+        "rev": "1b1485546d85f6f6c7aadb10c4923dbc09633263",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
         "pyproject-nix": "pyproject-nix"
       },
       "locked": {
-        "lastModified": 1783578912,
-        "narHash": "sha256-LFBOFqdggX/FAzuDDPBKU8VHIb0IvHmh/8zCB+5QVCM=",
+        "lastModified": 1787213408,
+        "narHash": "sha256-suLrhesVm+p2hcPgWQMt4h9ApPTfGBppK0Zl5gzFNaU=",
         "owner": "minijackson",
         "repo": "sphinxcontrib-nixdomain",
-        "rev": "0958328e4ad1e488ec546303ed6397b98f86aa58",
+        "rev": "5cc5be81e0da0d5b699a32e0fa1c2cdffe4f804c",
         "type": "github"
       },
       "original": {
@@ -150,11 +150,11 @@
         "pyproject-nix": "pyproject-nix_2"
       },
       "locked": {
-        "lastModified": 1784143733,
-        "narHash": "sha256-8JlT2l/06KwgsuyKFz48fWNwgS6YNK4pvetE4emSah4=",
+        "lastModified": 1784909673,
+        "narHash": "sha256-XgK/fj/K6jcNRo/KmPtQwtitl6f+LL5PQpjj+TpslIg=",
         "owner": "minijackson",
         "repo": "sphinxcontrib-typstbuilder",
-        "rev": "26e9bd9920b2740629251c0c2a445cf814e59fbf",
+        "rev": "002fe550e9d28900a2b53df81dc12942c70ea787",
         "type": "github"
       },
       "original": {

--- a/nixos/phoebus-ecosystem/phoebus-services.nix
+++ b/nixos/phoebus-ecosystem/phoebus-services.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  pkgs,
-  ports,
-  ...
-}:
+{ pkgs, ports, ... }:
 {
   services = {
     # Phoebus services
@@ -86,9 +81,10 @@
     ports.olog.port
   ];
 
-  nixpkgs.config.allowUnfreePredicate =
-    pkg:
-    builtins.elem (lib.getName pkg) [
-      "elasticsearch"
-    ];
+  # Elasticsearch can be used as an SSPL-licensed software, which is
+  # not open-source. But as we're using it run tests, not exposing
+  # any service, this should be fine.
+  nixpkgs.config.allowUnfreePackages = [ "elasticsearch" ];
+  # While waiting for Nixpkgs' packaging of Elasticsearch 8 / 9.
+  nixpkgs.config.permittedInsecurePackages = [ pkgs.elasticsearch7.name ];
 }

--- a/nixos/tests/channel-finder/default.nix
+++ b/nixos/tests/channel-finder/default.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  epnixLib,
-  pkgs,
-  ...
-}:
+{ epnixLib, pkgs, ... }:
 let
   ioc = pkgs.epnix.support.callPackage ./ioc.nix { };
 in
@@ -23,7 +18,7 @@ in
           environment.systemPackages = [ pkgs.epnix.epics-base ];
 
           services.recceiver = {
-            enable = lib.mkDefault true;
+            enable = true;
 
             channelfinderapi.DEFAULT = {
               BaseURL = "http://localhost:8082/ChannelFinder";
@@ -72,14 +67,12 @@ in
             package = pkgs.elasticsearch7;
           };
 
-          nixpkgs.config.allowUnfreePredicate =
-            pkg:
-            builtins.elem (lib.getName pkg) [
-              # Elasticsearch can be used as an SSPL-licensed software, which is
-              # not open-source. But as we're using it run tests, not exposing
-              # any service, this should be fine.
-              "elasticsearch"
-            ];
+          # Elasticsearch can be used as an SSPL-licensed software, which is
+          # not open-source. But as we're using it run tests, not exposing
+          # any service, this should be fine.
+          nixpkgs.config.allowUnfreePackages = [ "elasticsearch" ];
+          # While waiting for Nixpkgs' packaging of Elasticsearch 8 / 9.
+          nixpkgs.config.permittedInsecurePackages = [ pkgs.elasticsearch7.name ];
 
           # Else some applications might get killed by the OOM killer
           virtualisation.memorySize = 2047;

--- a/nixos/tests/channel-finder/test_script.py
+++ b/nixos/tests/channel-finder/test_script.py
@@ -21,7 +21,7 @@ def get(uri: str) -> Any:
     return json.loads(result)
 
 
-with subtest("ChannelFinder connected to ElasticSearch"):
+with subtest("ChannelFinder connected to Elasticsearch"):
     status = get("")
     assert status["elastic"]["status"] == "Connected"
 

--- a/nixos/tests/phoebus/alarm.nix
+++ b/nixos/tests/phoebus/alarm.nix
@@ -34,11 +34,7 @@
       };
 
     server =
-      {
-        lib,
-        pkgs,
-        ...
-      }:
+      { pkgs, ... }:
       let
         serverAddr = "192.168.1.3";
         kafkaListenSockAddr = "${serverAddr}:9092";
@@ -123,14 +119,12 @@
           '';
         };
 
-        nixpkgs.config.allowUnfreePredicate =
-          pkg:
-          builtins.elem (lib.getName pkg) [
-            # Elasticsearch can be used as an SSPL-licensed software, which is
-            # not open-source. But as we're using it run tests, not exposing
-            # any service, this should be fine.
-            "elasticsearch"
-          ];
+        # Elasticsearch can be used as an SSPL-licensed software, which is
+        # not open-source. But as we're using it run tests, not exposing
+        # any service, this should be fine.
+        nixpkgs.config.allowUnfreePackages = [ "elasticsearch" ];
+        # While waiting for Nixpkgs' packaging of Elasticsearch 8 / 9.
+        nixpkgs.config.permittedInsecurePackages = [ pkgs.elasticsearch7.name ];
 
         virtualisation.memorySize = 3072;
       };

--- a/nixos/tests/phoebus/olog.nix
+++ b/nixos/tests/phoebus/olog.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  epnixLib,
-  ...
-}:
+{ epnixLib, ... }:
 {
   name = "phoebus-olog-simple-check";
   meta.maintainers = with epnixLib.maintainers; [ minijackson ];
@@ -28,14 +24,12 @@
           package = pkgs.elasticsearch7;
         };
 
-        nixpkgs.config.allowUnfreePredicate =
-          pkg:
-          builtins.elem (lib.getName pkg) [
-            # Elasticsearch can be used as an SSPL-licensed software, which is
-            # not open-source. But as we're using it run tests, not exposing
-            # any service, this should be fine.
-            "elasticsearch"
-          ];
+        # Elasticsearch can be used as an SSPL-licensed software, which is
+        # not open-source. But as we're using it run tests, not exposing
+        # any service, this should be fine.
+        nixpkgs.config.allowUnfreePackages = [ "elasticsearch" ];
+        # While waiting for Nixpkgs' packaging of Elasticsearch 8 / 9.
+        nixpkgs.config.permittedInsecurePackages = [ pkgs.elasticsearch7.name ];
 
         # Else phoebus-olog gets killed by the OOM killer
         virtualisation.memorySize = 2047;
@@ -59,7 +53,7 @@
     status_str = client.succeed("curl -sSfL -k http://server:8181/Olog")
     status = json.loads(status_str)
 
-    with subtest("Olog connected to ElasticSearch"):
+    with subtest("Olog connected to Elasticsearch"):
         assert status["elastic"]["status"] == "Connected"
 
     with subtest("Olog connected to MongoDB (FerretDB)"):

--- a/nixos/tests/phoebus/save-and-restore.nix
+++ b/nixos/tests/phoebus/save-and-restore.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  epnixLib,
-  ...
-}:
+{ epnixLib, ... }:
 {
   name = "phoebus-save-and-restore-simple-check";
   meta.maintainers = with epnixLib.maintainers; [ minijackson ];
@@ -26,14 +22,12 @@
           package = pkgs.elasticsearch7;
         };
 
-        nixpkgs.config.allowUnfreePredicate =
-          pkg:
-          builtins.elem (lib.getName pkg) [
-            # Elasticsearch can be used as an SSPL-licensed software, which is
-            # not open-source. But as we're using it run tests, not exposing
-            # any service, this should be fine.
-            "elasticsearch"
-          ];
+        # Elasticsearch can be used as an SSPL-licensed software, which is
+        # not open-source. But as we're using it run tests, not exposing
+        # any service, this should be fine.
+        nixpkgs.config.allowUnfreePackages = [ "elasticsearch" ];
+        # While waiting for Nixpkgs' packaging of Elasticsearch 8 / 9.
+        nixpkgs.config.permittedInsecurePackages = [ pkgs.elasticsearch7.name ];
 
         # Else OOM
         virtualisation.memorySize = 2047;

--- a/pkgs/by-name/channel-finder-service/package.nix
+++ b/pkgs/by-name/channel-finder-service/package.nix
@@ -25,7 +25,7 @@ maven.buildMavenPackage rec {
   buildOffline = true;
   mvnJdk = jdk25_headless;
   mvnHash = "sha256-zd03/FAGS8LtdEDjgD7JZjgCaMso/akuUfjlR7wQM7k=";
-  # Tests require setting up ElasticSearch and Docker
+  # Tests require setting up Elasticsearch and Docker
   mvnParameters = "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z -DskipTests";
 
   # Dynamic test dependencies


### PR DESCRIPTION
Nixpkgs justed marked Elasticsearch as insecure, due to it being end-of-life and having CVEs, but currently doesn't have packages for Elasticsearch 8 or 9. This PR updates the tests, the phoebus-ecosystem VM, and the docs to indicate how to still opt-in to Elasticsearch 7 meanwhile.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [x] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [x] The feature is documented
    - [x] The documentation is up to date
    - Release notes:
        - [x] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
