### PR TITLE
nixos/iocs: check the existence of `workingDirectory` in `package`

### DIFF
--- a/docs/release-notes/2611.md
+++ b/docs/release-notes/2611.md
@@ -9,4 +9,11 @@ No breaking change were introduced in this EPNix release.
 
 ## New features and highlights
 
+- The {option}`services.iocs` module now checks
+  if the specified {option}`~services.iocs.<name>.workingDirectory` exists
+  in the IOC {option}`~services.iocs.<name>.package`
+  during the NixOS build.
+  This prevents deploying an IOC
+  with a wrongly named {term}``iocBoot directory``.
+
 ## Documentation

--- a/nixos/modules/iocs.nix
+++ b/nixos/modules/iocs.nix
@@ -264,6 +264,18 @@ let
         };
       };
     };
+
+  # Check that the specified `workingDirectory` does exist
+  # before allowing deployment
+  checkWorkingDirectory =
+    cfg:
+    pkgs.runCommand "check-ioc-${cfg.name}-has-working-directory" { } ''
+      if [ ! -d "${cfg.package}/${cfg.workingDirectory}/" ]; then
+        echo "The package of IOC service '${cfg.name}': '${cfg.package}' doesn't have the specified working directory '${cfg.workingDirectory}'."
+        exit 1
+      fi
+      touch $out
+    '';
 in
 {
   options.services.iocs = lib.mkOption {
@@ -300,5 +312,7 @@ in
       # The generated telnet scripts
       (lib.mapAttrsToList (_name: config: config.generatedTelnetScript) cfg)
     ];
+
+    system.checks = lib.mapAttrsToList (_name: iocCfg: checkWorkingDirectory iocCfg) cfg;
   };
 }


### PR DESCRIPTION
To prevent deploying an IOC with a wrongly named `iocBoot` folder.

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [x] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [x] Added an entry when adding a new feature
