### PR TITLE
nixos/tests/p4p: fix timeout on slow machines

### DIFF
--- a/nixos/tests/p4p.nix
+++ b/nixos/tests/p4p.nix
@@ -100,6 +100,7 @@
     start_all()
 
     server.wait_for_unit("p4p-server.service")
+    server.wait_until_succeeds("pvget test")
 
     commands = ["pvput test $TEST_VAL && pvget test | grep $TEST_VAL", "p4p-client"]
     machines = [client, server]


### PR DESCRIPTION
It appears that on slow machines, the first `pvput && pvget | grep` command fails with a timeout, because the P4P IOC didn't have time to properly initialize.

cc @Synthetica9 

<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [x] The feature has automated tests
    - [x] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
