### PR TITLE
phoebus-ecosystem/virtualbox-image: use stable name

### DIFF
--- a/nixos/phoebus-ecosystem/configuration.nix
+++ b/nixos/phoebus-ecosystem/configuration.nix
@@ -97,12 +97,9 @@
         https://epics-extensions.github.io/EPNix/${epnixLib.versions.current}/pkgs/user-guides/phoebus-ecosystem-vm.html'';
   };
 
-  system.nixos.label =
-    let
-      inherit (epnixLib.inputs) self;
-      rev = self.dirtyShortRev or self.shortRev or "unknown";
-    in
-    "${config.system.nixos.release}-${rev}";
+  # Set to something stable, to avoid having to rebuild it on every Nixpkgs or EPNix commit,
+  # since it's pretty expensive to build.
+  system.nixos.label = "${config.system.nixos.release}";
 
   system.stateVersion = lib.trivial.release;
 }


### PR DESCRIPTION
This should prevent having to rebuild the OVA on each EPNix commit, it's pretty expensive to build.


<!-- ^^^ Describe your changes here ^^^ -->

## Checklist

<!--
    Check all that apply.

    Note that these are not all required,
    but serves as information for reviewers.
-->

- Testing:
    - [ ] The feature has automated tests
    - [ ] Tests were run
    - If not, explain how you tested your changes

- Documentation:
    - [ ] The feature is documented
    - [ ] The documentation is up to date
    - Release notes:
        - [ ] Added an entry if the change is breaking or significant
        - [ ] Added an entry when adding a new feature
